### PR TITLE
added permission request for email

### DIFF
--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -14,6 +14,7 @@ module.exports = function(app) {
 
 	// Setting the facebook oauth routes
 	app.get('/auth/facebook', passport.authenticate('facebook', {
+		scope: ['email'],
 		failureRedirect: '/#!/signin'
 	}), users.signin);
 	app.get('/auth/facebook/callback', passport.authenticate('facebook', {


### PR DESCRIPTION
the application will trigger an error is this is not added here, since you won't have access to user's email in passport's facebook strategy.
