### PR TITLE
ensure NODE_ENV is valid and default regex for walk

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,6 +1,14 @@
 'use strict';
 
-var _ = require('lodash');
+var _ = require('lodash'),
+	utilities = require('./utilities');
 
-// Load app configuration
-module.exports = _.merge(require(__dirname + '/../config/env/all.js'), require(__dirname + '/../config/env/' + process.env.NODE_ENV + '.js') || {});
+process.env.NODE_ENV = ~utilities.walk('./config/env', /(.*)\.js$/).map(function(file) {
+	return file.split('/').pop().slice(0, -3);
+}).indexOf(process.env.NODE_ENV) ? process.env.NODE_ENV : 'development';
+
+// Load app configurations
+module.exports = _.extend(
+	require('./env/all'),
+	require('./env/' + process.env.NODE_ENV) || {}
+);

--- a/config/express.js
+++ b/config/express.js
@@ -9,7 +9,6 @@ var express = require('express'),
 	flash = require('connect-flash'),
 	config = require('./config'),
 	consolidate = require('consolidate'),
-	swig = require('swig'),
 	path = require('path'),
 	utilities = require('./utilities');
 
@@ -18,7 +17,7 @@ module.exports = function(db) {
 	var app = express();
 
 	// Initialize models
-	utilities.walk('./app/models', /(.*)\.(js$|coffee$)/).forEach(function(modelPath) {
+	utilities.walk('./app/models').forEach(function(modelPath) {
 		require(path.resolve(modelPath));
 	});
 
@@ -58,7 +57,7 @@ module.exports = function(db) {
 
 	// Application Configuration for development environment
 	app.configure('development', function() {
-		// Enable logger 
+		// Enable logger
 		app.use(express.logger('dev'));
 
 		// Disable views cache
@@ -106,7 +105,7 @@ module.exports = function(db) {
 	app.use(express.static(config.root + '/public'));
 
 	// Load Routes
-	utilities.walk('./app/routes', /(.*)\.(js$|coffee$)/).forEach(function(routePath) {
+	utilities.walk('./app/routes').forEach(function(routePath) {
 		require(path.resolve(routePath))(app);
 	});
 

--- a/config/passport.js
+++ b/config/passport.js
@@ -21,7 +21,7 @@ module.exports = function() {
 	});
 
 	// Initialize strategies
-	utilities.walk('./config/strategies', /(.*)\.(js$|coffee$)/).forEach(function(strategyPath) {
+	utilities.walk('./config/strategies').forEach(function(strategyPath) {
 		require(path.resolve(strategyPath))();
 	});
 };

--- a/config/utilities.js
+++ b/config/utilities.js
@@ -9,8 +9,9 @@ var fs = require('fs');
 var _walk = function(root, includeRegex, excludeRegex, removePath) {
 	var output = [];
 	var directories = [];
+	includeRegex = includeRegex || /(.*)\.(js|coffee)$/;
 
-	// First read through files 
+	// First read through files
 	fs.readdirSync(root).forEach(function(file) {
 		var newPath = root + '/' + file;
 		var stat = fs.statSync(newPath);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,7 +6,7 @@
 var utilities = require('./config/utilities');
 
 // Grabbing module files using the walk function
-var modulesJSFiles = utilities.walk('./public/modules', /(.*)\.(js)/, null, null);
+var modulesJSFiles = utilities.walk('./public/modules', /(.*)\.js$/);
 
 // Karma configuration
 module.exports = function(config) {

--- a/server.js
+++ b/server.js
@@ -1,11 +1,6 @@
 'use strict';
 
 /**
- * First we set the node enviornment variable if not set before
- */
-process.env.NODE_ENV = process.env.NODE_ENV || 'development';
-
-/**
  * Module dependencies.
  */
 var config = require('./config/config'),


### PR DESCRIPTION
- Move NODE_ENV determination into `config.js` and make sure it is valid. Otherwise, default to `development`.
- Set `/(.*)\.(js|coffee)$/` as the default regex for walk utility, as this is the most prevalent case. Centralizing adheres to DRY and reduces possibility of copy/paste error.
