### PR TITLE
Add envvars for deploying to cloud providers

### DIFF
--- a/config/env/all.js
+++ b/config/env/all.js
@@ -3,6 +3,9 @@
 var path = require('path'),
 	rootPath = path.normalize(__dirname + '/../..');
 
+var port = process.env.PORT || 3000;
+var appUrl = process.env.APP_URL || ('http://localhost:' + port);
+
 module.exports = {
 	app: {
 		title: 'MEAN.JS',
@@ -10,8 +13,9 @@ module.exports = {
 		keywords: 'mongodb, express, angularjs, node.js, mongoose, passport'
 	},
 	root: rootPath,
-	port: process.env.PORT || 3000,
+	port: port,
+	appUrl: appUrl,
 	templateEngine: 'swig',
-	sessionSecret: 'MEAN',
+	sessionSecret: process.env.SESSION_SECRET || 'MEAN',
 	sessionCollection: 'sessions'
 };

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -6,23 +6,23 @@ module.exports = {
 		title: 'MEAN.JS - Development Environment'
 	},
 	facebook: {
-		clientID: 'APP_ID',
-		clientSecret: 'APP_SECRET',
-		callbackURL: 'http://localhost:3000/auth/facebook/callback'
+		clientID: process.env.FACEBOOK_ID || 'APP_ID',
+		clientSecret: process.env.FACEBOOK_SECRET || 'APP_SECRET',
+		callbackPath: '/auth/facebook/callback'
 	},
 	twitter: {
-		clientID: 'CONSUMER_KEY',
-		clientSecret: 'CONSUMER_SECRET',
-		callbackURL: 'http://localhost:3000/auth/twitter/callback'
+		clientID: process.env.TWITTER_KEY || 'CONSUMER_KEY',
+		clientSecret: process.env.TWITTER_SECRET || 'CONSUMER_SECRET',
+		callbackPath: '/auth/twitter/callback'
 	},
 	google: {
-		clientID: 'APP_ID',
-		clientSecret: 'APP_SECRET',
-		callbackURL: 'http://localhost:3000/auth/google/callback'
+		clientID: process.env.GOOGLE_ID || 'APP_ID',
+		clientSecret: process.env.GOOGLE_SECRET || 'APP_SECRET',
+		callbackPath: '/auth/google/callback'
 	},
 	linkedin: {
-		clientID: 'APP_ID',
-		clientSecret: 'APP_SECRET',
-		callbackURL: 'http://localhost:3000/auth/linkedin/callback'
+		clientID: process.env.LINKEDIN_ID || 'APP_ID',
+		clientSecret: process.env.LINKEDIN_SECRET || 'APP_SECRET',
+		callbackPath: '/auth/linkedin/callback'
 	}
 };

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -3,23 +3,23 @@
 module.exports = {
     db: process.env.MONGOHQ_URL || process.env.MONGOLAB_URI || 'mongodb://localhost/mean',
 	facebook: {
-		clientID: 'APP_ID',
-		clientSecret: 'APP_SECRET',
-		callbackURL: 'http://localhost:3000/auth/facebook/callback'
+		clientID: process.env.FACEBOOK_ID || 'APP_ID',
+		clientSecret: process.env.FACEBOOK_SECRET || 'APP_SECRET',
+		callbackPath: '/auth/facebook/callback'
 	},
 	twitter: {
-		clientID: 'CONSUMER_KEY',
-		clientSecret: 'CONSUMER_SECRET',
-		callbackURL: 'http://localhost:3000/auth/twitter/callback'
+		clientID: process.env.TWITTER_KEY || 'CONSUMER_KEY',
+		clientSecret: process.env.TWITTER_SECRET || 'CONSUMER_SECRET',
+		callbackPath: '/auth/twitter/callback'
 	},
 	google: {
-		clientID: 'APP_ID',
-		clientSecret: 'APP_SECRET',
-		callbackURL: 'http://localhost:3000/auth/google/callback'
+		clientID: process.env.GOOGLE_ID || 'APP_ID',
+		clientSecret: process.env.GOOGLE_SECRET || 'APP_SECRET',
+		callbackPath: '/auth/google/callback'
 	},
 	linkedin: {
-		clientID: 'APP_ID',
-		clientSecret: 'APP_SECRET',
-		callbackURL: 'http://localhost:3000/auth/linkedin/callback'
+		clientID: process.env.LINKEDIN_ID || 'APP_ID',
+		clientSecret: process.env.LINKEDIN_SECRET || 'APP_SECRET',
+		callbackPath: '/auth/linkedin/callback'
 	}
 };

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -7,23 +7,23 @@ module.exports = {
 		title: 'MEAN.JS - Test Environment'
 	},
 	facebook: {
-		clientID: 'APP_ID',
-		clientSecret: 'APP_SECRET',
-		callbackURL: 'http://localhost:3000/auth/facebook/callback'
+		clientID: process.env.FACEBOOK_ID || 'APP_ID',
+		clientSecret: process.env.FACEBOOK_SECRET || 'APP_SECRET',
+		callbackPath: '/auth/facebook/callback'
 	},
 	twitter: {
-		clientID: 'CONSUMER_KEY',
-		clientSecret: 'CONSUMER_SECRET',
-		callbackURL: 'http://localhost:3000/auth/twitter/callback'
+		clientID: process.env.TWITTER_KEY || 'CONSUMER_KEY',
+		clientSecret: process.env.TWITTER_SECRET || 'CONSUMER_SECRET',
+		callbackPath: '/auth/twitter/callback'
 	},
 	google: {
-		clientID: 'APP_ID',
-		clientSecret: 'APP_SECRET',
-		callbackURL: 'http://localhost:3000/auth/google/callback'
+		clientID: process.env.GOOGLE_ID || 'APP_ID',
+		clientSecret: process.env.GOOGLE_SECRET || 'APP_SECRET',
+		callbackPath: '/auth/google/callback'
 	},
 	linkedin: {
-		clientID: 'APP_ID',
-		clientSecret: 'APP_SECRET',
-		callbackURL: 'http://localhost:3000/auth/linkedin/callback'
+		clientID: process.env.LINKEDIN_ID || 'APP_ID',
+		clientSecret: process.env.LINKEDIN_SECRET || 'APP_SECRET',
+		callbackPath: '/auth/linkedin/callback'
 	}
 };

--- a/config/strategies/facebook.js
+++ b/config/strategies/facebook.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var passport = require('passport'),
+	url = require('url'),
 	FacebookStrategy = require('passport-facebook').Strategy,
 	User = require('mongoose').model('User'),
 	config = require('../config');
@@ -10,7 +11,7 @@ module.exports = function() {
 	passport.use(new FacebookStrategy({
 			clientID: config.facebook.clientID,
 			clientSecret: config.facebook.clientSecret,
-			callbackURL: config.facebook.callbackURL,
+			callbackURL: url.resolve(config.appUrl, config.facebook.callbackPath),
 			passReqToCallback: true
 		},
 		function(req, accessToken, refreshToken, profile, done) {

--- a/config/strategies/google.js
+++ b/config/strategies/google.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var passport = require('passport'),
+	url = require('url'),
 	GoogleStrategy = require('passport-google-oauth').OAuth2Strategy,
 	User = require('mongoose').model('User'),
 	config = require('../config');
@@ -10,7 +11,7 @@ module.exports = function() {
 	passport.use(new GoogleStrategy({
 			clientID: config.google.clientID,
 			clientSecret: config.google.clientSecret,
-			callbackURL: config.google.callbackURL,
+			callbackURL: url.resolve(config.appUrl, config.google.callbackPath),
 			passReqToCallback: true
 		},
 		function(req, accessToken, refreshToken, profile, done) {

--- a/config/strategies/linkedin.js
+++ b/config/strategies/linkedin.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var passport = require('passport'),
+	url = require('url'),
 	LinkedInStrategy = require('passport-linkedin').Strategy,
 	User = require('mongoose').model('User'),
 	config = require('../config');
@@ -10,7 +11,7 @@ module.exports = function() {
 	passport.use(new LinkedInStrategy({
 			consumerKey: config.linkedin.clientID,
 			consumerSecret: config.linkedin.clientSecret,
-			callbackURL: config.linkedin.callbackURL,
+			callbackURL: url.resolve(config.appUrl, config.linkedin.callbackPath),
 			passReqToCallback: true,
 			profileFields: ['id', 'first-name', 'last-name', 'email-address']
 		},

--- a/config/strategies/twitter.js
+++ b/config/strategies/twitter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var passport = require('passport'),
+	url = require('url'),
 	TwitterStrategy = require('passport-twitter').Strategy,
 	User = require('mongoose').model('User'),
 	config = require('../config');
@@ -10,7 +11,7 @@ module.exports = function() {
 	passport.use(new TwitterStrategy({
 			consumerKey: config.twitter.clientID,
 			consumerSecret: config.twitter.clientSecret,
-			callbackURL: config.twitter.callbackURL,
+			callbackURL: url.resolve(config.appUrl, config.twitter.callbackPath),
 			passReqToCallback: true
 		},
 		function(req, token, tokenSecret, profile, done) {


### PR DESCRIPTION
Added some more environment variables to the code. 
It makes easier to deploy heroku. Also, when developing locally, permits you to connect to OAuth providers without modifying production.js/development.js/test.js (or commiting keys/secrets to VCS by mistake).
## Heroku

heroku config:add \
  FACEBOOK_ID='facebook-id' \
  FACEBOOK_SECRET='facebook-secret' \
  TWITTER_KEY='twitter-id' \
  TWITTER_SECRET='twitter-secret' \
  GOOGLE_ID='google-id' \
  GOOGLE_SECRET='google-secret' \
  GITHUB_ID='github-id' \
  GITHUB_SECRET='github-secret'\
  SESSION_SECRET='your session secret for express sessions' \
  NODE_ENV='production' \
  APP_URL='your-app-name-in.heroku.com'
## Locally

export \
 FACEBOOK_ID='facebook-id' \
  FACEBOOK_SECRET='facebook-secret' \
  TWITTER_KEY='twitter-id' \
  TWITTER_SECRET='twitter-secret' \
  GOOGLE_ID='google-id' \
  GOOGLE_SECRET='google-secret' \
  GITHUB_ID='github-id' \
  GITHUB_SECRET='github-secret'\
  SESSION_SECRET='your session secret for express sessions' \
  PORT=9000 \
  NODE_ENV='development'
  APP_URL='your-app-name-in.heroku.com'

Cheers
