### PR TITLE
The server crashes when I try to login with username and password to an oauth account.

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -104,6 +104,9 @@ UserSchema.methods.hashPassword = function(password) {
  * Create instance method for authenticating user
  */
 UserSchema.methods.authenticate = function(password) {
+	if (!this.password || !this.salt) {
+		return false;
+	}
 	return this.password === this.hashPassword(password);
 };
 


### PR DESCRIPTION
Problem: 
The salt is only set on local authentication. Otherwise it is undefined.

To reproduce the error:
- sign in only with an oauth strategy (without local strategy)
- copy your username
- logout 
- try to login with the copied username and a random password
- server crashes in the hasPassword function of the user model

```
crypto.js:570
    return binding.PBKDF2(password, salt, iterations, keylen, callback);
```

I added a check of password and salt in user auth.
