### PR TITLE
Fixes #45 - Npm install error on 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"passport-linkedin": "~0.1.3",
 		"passport-google-oauth": "~0.1.5",
 		"lodash": "~2.4.1",
-		"forever": "~0.11.00",
+		"forever": "~0.11.0",
 		"bower": "~1.3.1",
 		"grunt-cli": "~0.1.13"
 	},


### PR DESCRIPTION
The double 00 causes a problem in `npm install` see issue #45
