### PR TITLE
Fixing module deps in angular

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -7,9 +7,9 @@ var ApplicationConfiguration = (function() {
 	var applicationModuleVendorDependencies = ['ngResource', 'ngAnimate', 'ui.router', 'ui.bootstrap', 'ui.utils'];
 
 	// Add a new vertical module
-	var registerModule = function(moduleName) {
+	var registerModule = function(moduleName, moduleDeps) {
 		// Create angular module
-		angular.module(moduleName, []);
+		angular.module(moduleName, moduleDeps);
 
 		// Add the module to the AngularJS configuration file
 		angular.module(applicationModuleName).requires.push(moduleName);

--- a/public/modules/articles/articles.client.module.js
+++ b/public/modules/articles/articles.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use Applicaion configuration module to register a new module
-ApplicationConfiguration.registerModule('articles');
+ApplicationConfiguration.registerModule('articles', []);

--- a/public/modules/core/core.client.module.js
+++ b/public/modules/core/core.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use Applicaion configuration module to register a new module
-ApplicationConfiguration.registerModule('core');
+ApplicationConfiguration.registerModule('core', []);

--- a/public/modules/users/users.client.module.js
+++ b/public/modules/users/users.client.module.js
@@ -1,4 +1,4 @@
 'use strict';
 
 // Use Applicaion configuration module to register a new module
-ApplicationConfiguration.registerModule('users');
+ApplicationConfiguration.registerModule('users', []);


### PR DESCRIPTION
Hello everybody. I am a little bit confused not how to add extra modules on my angular controllers. In my project I wanted to use `ngTables` and `ngRoutes` instead of using the default modules written in `public/config.js:7`

I tried to alter the default array and put my dependences but angular wasn't recognize them at all. So I did this change on my pull request meanjs/mean#65 and it worked perfectly.

It is a bug?
