### PR TITLE
Remove ng-init directive from article list.

### DIFF
--- a/public/modules/articles/controllers/articles.client.controller.js
+++ b/public/modules/articles/controllers/articles.client.controller.js
@@ -2,6 +2,10 @@
 
 angular.module('articles').controller('ArticlesController', ['$scope', '$stateParams', '$location', 'Authentication', 'Articles',
 	function($scope, $stateParams, $location, Authentication, Articles) {
+		function updateArticleList() {
+			$scope.articles = Articles.query();
+		}
+
 		$scope.authentication = Authentication;
 
 		$scope.create = function() {
@@ -45,14 +49,12 @@ angular.module('articles').controller('ArticlesController', ['$scope', '$statePa
 			});
 		};
 
-		$scope.find = function() {
-			$scope.articles = Articles.query();
-		};
-
 		$scope.findOne = function() {
 			$scope.article = Articles.get({
 				articleId: $stateParams.articleId
 			});
 		};
+
+		updateArticleList();
 	}
 ]);

--- a/public/modules/articles/tests/articles.client.controller.test.js
+++ b/public/modules/articles/tests/articles.client.controller.test.js
@@ -8,7 +8,8 @@
 			scope,
 			$httpBackend,
 			$stateParams,
-			$location;
+			$location,
+			sampleArticles;
 
 		// The $resource service augments the response object with methods for updating and deleting the resource.
 		// If we were to use the standard toEqual matcher, our tests would fail because the test values would not match
@@ -50,23 +51,25 @@
 			});
 		}));
 
-		it('$scope.find() should create an array with at least one article object fetched from XHR', inject(function(Articles) {
+		// Handle controller initialization logic and data fixtures
+		beforeEach(inject(function(Articles) {
 			// Create sample article using the Articles service
 			var sampleArticle = new Articles({
 				title: 'An Article about MEAN',
 				content: 'MEAN rocks!'
 			});
 
-			// Create a sample articles array that includes the new article
-			var sampleArticles = [sampleArticle];
+			// Add the sample article to the sampleArticles array
+			sampleArticles = [sampleArticle];
 
 			// Set GET response
 			$httpBackend.expectGET('articles').respond(sampleArticles);
 
-			// Run controller functionality
-			scope.find();
+			// Run the controller initialization functionality
 			$httpBackend.flush();
+		}));
 
+		it('should update the list of Articles on initialization', inject(function(Articles) {
 			// Test scope value
 			expect(scope.articles).toEqualData(sampleArticles);
 		}));

--- a/public/modules/articles/views/list-articles.client.view.html
+++ b/public/modules/articles/views/list-articles.client.view.html
@@ -1,4 +1,4 @@
-<section data-ng-controller="ArticlesController" data-ng-init="find()">
+<section data-ng-controller="ArticlesController">
     <div class="page-header">
         <h1>Articles</h1>
     </div>


### PR DESCRIPTION
According to the [AngularJS Docs](https://docs.angularjs.org/api/ng/directive/ngInit), the `ng-init` directive should only be used for aliasing special properties of ngRepeat.

This PR replaces the unintended usage of ngInit with a safer convention: using a private function to populate the Articles list on initialization of the Controller.

With the current implementation, this does mean an extra call to list the articles in states where it's not appropriate (i.e. CRUD states). Ideally, the ArticlesController would be split into two smaller controllers that handled only one concern (`ArticleController` for single item CRUD, `ArticleListController` for listing all articles and batch actions). This split would prevent the extra server call in CRUD states. This PR refrains from such refactoring because it seemed too large for a single PR. If implementation of this split is preferred before merge, I'd be happy to revise.
