### PR TITLE
.editorconfig based on Felix style guide

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,49 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# Howto with your editor:
+#   Sublime: https://github.com/sindresorhus/editorconfig-sublime
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[**]
+end_of_line = lf
+insert_final_newline = true
+
+# Standard at: https://github.com/felixge/node-style-guide 
+[**.js, **.json]
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+max_line_length = 80
+quote_type = single
+curly_bracket_next_line = false
+spaces_around_operators = true
+space_after_control_statements = true
+space_after_anonymous_functions = false
+spaces_in_brackets = false
+
+# https://github.com/jedmao/codepainter
+[node_modules/**.js]
+codepaint = false
+
+# No Standard.  Please document a standard if different from .js
+[**.yml, **.html, **.css]
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# No standard.  Please document a standard if different from .js
+[**.md]
+indent_style = space
+
+# Standard at:
+[**.py]
+indent_style = space
+indent_size = 4
+
+# Standard at: 
+[Makefile]
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
Here's a controversial commit :-)  

There was general agreement about having a .editorconfig here: https://github.com/meanjs/mean/pull/63

This adds an .editorconfig based on the Felix Node.js Style Guide.  It's a best attempt to stay true to Node.js style.  

I'm far more opinionated about having a standard, than the standard itself.  The close wer are to a standard shared by the Node.js community, the easier it will be to bring new coders into our community.

Not all of these options will have the same effect (or any) in every editor.  

Please comment!
