### PR TITLE
Add cluster support

### DIFF
--- a/config/env/all.js
+++ b/config/env/all.js
@@ -7,6 +7,7 @@ module.exports = {
 		keywords: 'mongodb, express, angularjs, node.js, mongoose, passport'
 	},
 	port: process.env.PORT || 3000,
+	workers: 1,
 	templateEngine: 'swig',
 	sessionSecret: 'MEAN',
 	sessionCollection: 'sessions',

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@
  * Module dependencies.
  */
 var init = require('./config/init')(),
+	cluster = require('cluster'),
 	config = require('./config/config'),
 	mongoose = require('mongoose');
 
@@ -20,11 +21,35 @@ var app = require('./config/express')(db);
 // Bootstrap passport config
 require('./config/passport')();
 
-// Start the app by listening on <port>
-app.listen(config.port);
 
-// Expose app
-exports = module.exports = app;
+if (cluster.isMaster) {
+	var debug = process.execArgv.indexOf('--debug') !== -1;
+	cluster.setupMaster({
+		execArgv: process.execArgv.filter(function(s) { return s !== '--debug'; })
+	});
 
-// Logging initialization
-console.log('MEAN.JS application started on port ' + config.port);
+	cluster.on('exit', function(worker, code, signal) {
+		console.dir(arguments);
+		cluster.fork();
+	});
+
+	console.log('MEAN.JS application starting on port ' + config.port);
+	for (var i = 0; i < config.workers; ++i) {
+		if (debug) {
+			cluster.settings.execArgv.push('--debug=' + (5859 + i));
+			cluster.fork();
+			cluster.settings.execArgv.pop();
+		}
+		else {
+			cluster.fork();
+		}
+	}
+}
+else {
+	// Start the app by listening on <port>
+	app.listen(config.port);
+
+	console.log('MEAN.JS Worker #' + cluster.worker.id + ' started');
+	// Expose app
+	exports = module.exports = app;
+}


### PR DESCRIPTION
+ Number of workers specified in new config var 'worker' located in config/env/all.js, default is 1.
+ In order to handle debugging, implemented workaround discussed in comment: [joyent/node#5318](https://github.com/joyent/node/issues/5318#issuecomment-16702390)