### PR TITLE
Remove space which messes up the url local variable

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -39,7 +39,7 @@ module.exports = function(db) {
 
 	// Passing the request url to environment locals
 	app.use(function(req, res, next) {
-		res.locals.url = req.protocol + ':// ' + req.headers.host + req.url;
+		res.locals.url = req.protocol + '://' + req.headers.host + req.url;
 		next();
 	});
 


### PR DESCRIPTION
There is an extra space for the definition of url local variable in express.js.
