### PR TITLE
bug fix: MenuItem and SubMenuItem could not be created with isPublic === false

### DIFF
--- a/public/modules/core/services/menus.client.service.js
+++ b/public/modules/core/services/menus.client.service.js
@@ -85,7 +85,7 @@ angular.module('core').service('Menus', [
 				menuItemType: menuItemType || 'item',
 				menuItemClass: menuItemType,
 				uiRoute: menuItemUIRoute || ('/' + menuItemURL),
-				isPublic: isPublic || this.menus[menuId].isPublic,
+				isPublic: isPublic === null && this.menus[menuId].isPublic || isPublic,
 				roles: roles || this.defaultRoles,
 				items: [],
 				shouldRender: shouldRender
@@ -108,7 +108,7 @@ angular.module('core').service('Menus', [
 						title: menuItemTitle,
 						link: menuItemURL,
 						uiRoute: menuItemUIRoute || ('/' + menuItemURL),
-						isPublic: isPublic || this.menus[menuId].isPublic,
+						isPublic: isPublic === null && this.menus[menuId].isPublic || isPublic,
 						roles: roles || this.defaultRoles,
 						shouldRender: shouldRender
 					});


### PR DESCRIPTION
Whenever the user created a new MenuItem or SubMenuItem with isPublic === false, isPublic was defaulted to the same value of the parent menu due to a bug in the comparison.
