### PR TITLE
Fix typo in Error handling controller code

### DIFF
--- a/app/controllers/errors.server.controller.js
+++ b/app/controllers/errors.server.controller.js
@@ -8,10 +8,10 @@ var getUniqueErrorMessage = function(err) {
 
 	try {
 		var fieldName = err.err.substring(err.err.lastIndexOf('.$') + 2, err.err.lastIndexOf('_1'));
-		output = fieldName.charAt(0).toUpperCase() + fieldName.slice(1) + ' already exist';
+		output = fieldName.charAt(0).toUpperCase() + fieldName.slice(1) + ' already exists';
 
 	} catch(ex) {
-		output = 'Unique field already exist';
+		output = 'Unique field already exists';
 	}
 
 	return output;


### PR DESCRIPTION
On the frontend, the error message 'Username already exist' appears when creating a user with the same username as an existing user.  Grammatically, this error looks strange.  A more proper error message would be 'Username already exists'.  Possibly later on support can be added to properly conjugate this error message for a 'plural' field.

![problematicgrammar](https://cloud.githubusercontent.com/assets/5246841/3836311/43e8d6c2-1dd2-11e4-8138-0a9917f5f16c.png)
