### PR TITLE
Genericize invalid username or password message

### DIFF
--- a/config/strategies/local.js
+++ b/config/strategies/local.js
@@ -22,12 +22,12 @@ module.exports = function() {
 				}
 				if (!user) {
 					return done(null, false, {
-						message: 'Unknown user'
+						message: 'Unknown user or invalid password'
 					});
 				}
 				if (!user.authenticate(password)) {
 					return done(null, false, {
-						message: 'Invalid password'
+						message: 'Unknown user or invalid password'
 					});
 				}
 


### PR DESCRIPTION
See [issue 133](https://github.com/meanjs/mean/issues/133):
If the user has an invalid username or password, the message returned should not specify if the username or password was incorrect, rather, the message should be generic for both cases.
