### PR TITLE
Rise gunt-concurrent task limit.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -116,7 +116,8 @@ module.exports = function(grunt) {
 			default: ['nodemon', 'watch'],
 			debug: ['nodemon', 'watch', 'node-inspector'],
 			options: {
-				logConcurrentOutput: true
+				logConcurrentOutput: true,
+				limit: 10,
 			}
 		},
 		env: {


### PR DESCRIPTION
Fixes issue with default value for grunt-concurrent limit in machines with few cpu/cores.

From grunt-concurrent docs:

  limit

  Type: Number
  Default: Number of CPU cores (require('os').cpus().length) with a minimum of 2

  Limit of how many tasks that are run concurrently.

In machines with few cpus/cores, the default limit of 2 the 'grunt debug' task
can't start enough tasks for starting the node-inspector task, so the command fails
and the capp can't be debugged.

Fixes issue #144
