### PR TITLE
Adds support for re-running server and client tests automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ Your application should run on port 3000, so in your browser just go to [http://
 That's it! Your application should be running. To proceed with your development, check the other sections in this documentation.
 If you encounter any problems, try the Troubleshooting section.
 
+## Testing Your Application
+You can run the full test suite included with MEAN.JS with the test task:
+
+```
+$ grunt test
+```
+
+This will run both the server-side tests (located in the app/tests/ directory) and the client-side tests (located in the public/modules/*/tests/).
+
+To execute only the server tests, run the test:server task:
+
+```
+$ grunt test:server
+```
+
+And to run only the client tests, run the test:client task:
+
+```
+$ grunt test:client
+```
+
 ## Development and deployment With Docker
 
 * Install [Docker](http://www.docker.com/)

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -4,7 +4,7 @@ module.exports = function(grunt) {
 	// Unified Watch Object
 	var watchFiles = {
 		serverViews: ['app/views/**/*.*'],
-		serverJS: ['gruntfile.js', 'server.js', 'config/**/*.js', 'app/**/*.js'],
+		serverJS: ['gruntfile.js', 'server.js', 'config/**/*.js', 'app/**/*.js', '!app/tests/'],
 		clientViews: ['public/modules/**/views/**/*.html'],
 		clientJS: ['public/js/*.js', 'public/modules/**/*.js'],
 		clientCSS: ['public/modules/**/*.css'],
@@ -47,6 +47,10 @@ module.exports = function(grunt) {
 				options: {
 					livereload: true
 				}
+			},
+			mochaTests: {
+				files: watchFiles.mochaTests,
+				tasks: ['test:server'],
 			}
 		},
 		jshint: {
@@ -173,5 +177,7 @@ module.exports = function(grunt) {
 	grunt.registerTask('build', ['lint', 'loadConfig', 'ngAnnotate', 'uglify', 'cssmin']);
 
 	// Test task.
-	grunt.registerTask('test', ['env:test', 'mochaTest', 'karma:unit']);
+	grunt.registerTask('test', ['test:server', 'test:client']);
+	grunt.registerTask('test:server', ['env:test', 'mochaTest']);
+	grunt.registerTask('test:client', ['env:test', 'karma:unit']);
 };


### PR DESCRIPTION
Adds two more tasks to execute server and client tests separately

To run full suite
grunt test

To run only server tests
grunt test:server

To run only client tests
grunt test:client

Fixes https://github.com/meanjs/mean/issues/155