### PR TITLE
Use ng-annotate instead of ngmin

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -3,7 +3,7 @@
 module.exports = function(grunt) {
 	// Unified Watch Object
 	var watchFiles = {
-		serverViews: ['app/views/**/*.*'], 
+		serverViews: ['app/views/**/*.*'],
 		serverJS: ['gruntfile.js', 'server.js', 'config/**/*.js', 'app/**/*.js'],
 		clientViews: ['public/modules/**/views/**/*.html'],
 		clientJS: ['public/js/*.js', 'public/modules/**/*.js'],
@@ -105,7 +105,7 @@ module.exports = function(grunt) {
 				}
 			}
 		},
-        ngmin: {
+        ngAnnotate: {
             production: {
                 files: {
                     'public/dist/application.js': '<%= applicationJavaScriptFiles %>'
@@ -138,7 +138,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	// Load NPM tasks 
+	// Load NPM tasks
 	require('load-grunt-tasks')(grunt);
 
 	// Making grunt default to force in order not to break the project.
@@ -163,7 +163,7 @@ module.exports = function(grunt) {
 	grunt.registerTask('lint', ['jshint', 'csslint']);
 
 	// Build task(s).
-	grunt.registerTask('build', ['lint', 'loadConfig', 'ngmin', 'uglify', 'cssmin']);
+	grunt.registerTask('build', ['lint', 'loadConfig', 'ngAnnotate', 'uglify', 'cssmin']);
 
 	// Test task.
 	grunt.registerTask('test', ['env:test', 'mochaTest', 'karma:unit']);

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"grunt-contrib-watch": "~0.6.1",
 		"grunt-contrib-jshint": "~0.10.0",
 		"grunt-contrib-csslint": "^0.2.0",
-		"grunt-ngmin": "0.0.3",
+		"grunt-ng-annotate": "~0.3.2",
 		"grunt-contrib-uglify": "~0.5.1",
 		"grunt-contrib-cssmin": "~0.10.0",
 		"grunt-nodemon": "~0.3.0",


### PR DESCRIPTION
ngmin is deprecated and ng-annotate is the recommended replacement (https://github.com/olov/ng-annotate).

From ng-annotate [README.md](https://github.com/olov/ng-annotate/blob/master/README.md):
"Grunt users can migrate easily by installing [grunt-ng-annotate](https://www.npmjs.org/package/grunt-ng-annotate) and replacing `ngmin` with `ngAnnotate` in their Gruntfile."
