### PR TITLE
missing envs for docker / fig

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var DB_HOST = process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost';
+
 module.exports = {
-	db: 'mongodb://localhost/mean-dev',
+	db: 'mongodb://' + DB_HOST + '/mean-dev',
 	app: {
 		title: 'MEAN.JS - Development Environment'
 	},

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var DB_HOST = process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost';
+
 module.exports = {
-	db: process.env.MONGOHQ_URL || process.env.MONGOLAB_URI || 'mongodb://localhost/mean',
+	db: process.env.MONGOHQ_URL || process.env.MONGOLAB_URI || 'mongodb://' + DB_HOST + '/mean',
 	assets: {
 		lib: {
 			css: [

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var DB_HOST = process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost';
+
 module.exports = {
-	db: 'mongodb://localhost/mean-test',
+	db: 'mongodb://' + DB_HOST + '/mean-test',
 	port: 3001,
 	app: {
 		title: 'MEAN.JS - Test Environment'


### PR DESCRIPTION
As mentioned here: https://github.com/meanjs/mean/pull/101 the envs are missing. Reopened with this PR.

Currently the Docker integration is broken since the web container doesn't find the mongo container. It looks at localhost but rather should look at DB_1_PORT_27017_TCP_ADDR. 
