### PR TITLE
localhost hard coded URL for livereload.js bugfix

### DIFF
--- a/app/controllers/core.server.controller.js
+++ b/app/controllers/core.server.controller.js
@@ -5,6 +5,7 @@
  */
 exports.index = function(req, res) {
 	res.render('index', {
-		user: req.user || null
+		user: req.user || null,
+		request: req
 	});
 };

--- a/app/views/layout.server.view.html
+++ b/app/views/layout.server.view.html
@@ -61,7 +61,7 @@
 
 	{% if process.env.NODE_ENV === 'development' %}
 	<!--Livereload script rendered -->
-	<script type="text/javascript" src="http://localhost:35729/livereload.js"></script>
+	<script type="text/javascript" src="http://{{request.hostname}}:35729/livereload.js"></script>
 
 	{% endif %}
 </body>


### PR DESCRIPTION
introducing the request object for the index base HTML template which can utilize information such as the requests hostname, and more. This allows to specify the actual hostname for the livereload.js module instead of hard-coding localhost. closes https://github.com/meanjs/mean/issues/211
