### PR TITLE
Show error message when sending password request mail fails

### DIFF
--- a/app/controllers/users/users.password.server.controller.js
+++ b/app/controllers/users/users.password.server.controller.js
@@ -77,6 +77,10 @@ exports.forgot = function(req, res, next) {
 					res.send({
 						message: 'An email has been sent to ' + user.email + ' with further instructions.'
 					});
+				} else {
+					return res.status(400).send({
+						message: 'Failure sending email'
+					});
 				}
 
 				done(err);


### PR DESCRIPTION
It used to fail silently (client only displays error when a message is available).
