### PR TITLE
social buttons fix when html5mode is enabled - 0.4.0

### DIFF
--- a/modules/users/client/views/authentication/authentication.client.view.html
+++ b/modules/users/client/views/authentication/authentication.client.view.html
@@ -1,19 +1,19 @@
 <section class="row">
 	<h3 class="col-md-12 text-center">Sign in using your social accounts</h3>
 	<div class="col-md-12 text-center">
-		<a href="/api/auth/facebook" class="undecorated-link">
+		<a href="/api/auth/facebook" target="_self" class="undecorated-link">
 			<img src="/modules/users/img/buttons/facebook.png">
 		</a>
-		<a href="/api/auth/twitter" class="undecorated-link">
+		<a href="/api/auth/twitter" target="_self" class="undecorated-link">
 			<img src="/modules/users/img/buttons/twitter.png">
 		</a>
-		<a href="/api/auth/google" class="undecorated-link">
+		<a href="/api/auth/google" target="_self" class="undecorated-link">
 			<img src="/modules/users/img/buttons/google.png">
 		</a>
-		<a href="/api/auth/linkedin" class="undecorated-link">
+		<a href="/api/auth/linkedin" target="_self" class="undecorated-link">
 			<img src="/modules/users/img/buttons/linkedin.png">
 		</a>
-		<a href="/api/auth/github" class="undecorated-link">
+		<a href="/api/auth/github" target="_self" class="undecorated-link">
 			<img src="/modules/users/img/buttons/github.png">
 		</a>
 	</div>


### PR DESCRIPTION
Because html5Mode is enabled in 0.4.0, the social buttons links won't work. The links to /api/auth/{provider} will be captured by angular and ui-router will change the location back to /. Adding target="_self" to each link will fix this issue. Maybe creating a new directive for links to hit server side endpoints would be more appropriate.
