### PR TITLE
0.4.0 - 'username' deprecated in facebook api >=2.0

### DIFF
--- a/modules/users/server/config/strategies/facebook.js
+++ b/modules/users/server/config/strategies/facebook.js
@@ -14,7 +14,7 @@ module.exports = function(config) {
 			clientID: config.facebook.clientID,
 			clientSecret: config.facebook.clientSecret,
 			callbackURL: config.facebook.callbackURL,
-			profileFields: ['id', 'name', 'displayName', 'email', 'username', 'photos'],
+			profileFields: ['id', 'name', 'displayName', 'email', 'photos'],
 			passReqToCallback: true
 		},
 		function(req, accessToken, refreshToken, profile, done) {


### PR DESCRIPTION
When creating a user account using facebook oauth the error "(#12) username is deprecated for versions v2.0 and higher" is returned. Removing 'username' from the passport facebook strategy's 'profileFields' will correct this issue. The user account will be created using the local part of the user's email address as the username.