### PR TITLE
Angular services should be loaded first

### DIFF
--- a/config/env/all.js
+++ b/config/env/all.js
@@ -61,6 +61,8 @@ module.exports = {
 		js: [
 			'public/config.js',
 			'public/application.js',
+            'public/modules/*/*.module.js',
+            'public/modules/*/services/*.js',
 			'public/modules/*/*.js',
 			'public/modules/*/*[!tests]*/*.js'
 		],

--- a/config/env/all.js
+++ b/config/env/all.js
@@ -1,74 +1,74 @@
 'use strict';
 
 module.exports = {
-	app: {
-		title: 'MEAN.JS',
-		description: 'Full-Stack JavaScript with MongoDB, Express, AngularJS, and Node.js',
-		keywords: 'mongodb, express, angularjs, node.js, mongoose, passport'
-	},
-	port: process.env.PORT || 3000,
-	templateEngine: 'swig',
-	// The secret should be set to a non-guessable string that
-	// is used to compute a session hash
-	sessionSecret: 'MEAN',
-	// The name of the MongoDB collection to store sessions in
-	sessionCollection: 'sessions',
-	// The session cookie settings
-	sessionCookie: { 
-		path: '/',
-		httpOnly: true,
-		// If secure is set to true then it will cause the cookie to be set
-		// only when SSL-enabled (HTTPS) is used, and otherwise it won't
-		// set a cookie. 'true' is recommended yet it requires the above
-		// mentioned pre-requisite.
-		secure: false,
-		// Only set the maxAge to null if the cookie shouldn't be expired
-		// at all. The cookie will expunge when the browser is closed.
-		maxAge: null,
-		// To set the cookie in a specific domain uncomment the following 
-		// setting:
-		// domain: 'yourdomain.com'
-	},
-	// The session cookie name
-	sessionName: 'connect.sid',
-	log: {
-		// Can specify one of 'combined', 'common', 'dev', 'short', 'tiny'
-		format: 'combined',
-		// Stream defaults to process.stdout
-		// Uncomment to enable logging to a log on the file system
-		options: {
-			stream: 'access.log'
-		}
-	},
-	assets: {
-		lib: {
-			css: [
-				'public/lib/bootstrap/dist/css/bootstrap.css',
-				'public/lib/bootstrap/dist/css/bootstrap-theme.css',
-			],
-			js: [
-				'public/lib/angular/angular.js',
-				'public/lib/angular-resource/angular-resource.js',
-				'public/lib/angular-animate/angular-animate.js',
-				'public/lib/angular-ui-router/release/angular-ui-router.js',
-				'public/lib/angular-ui-utils/ui-utils.js',
-				'public/lib/angular-bootstrap/ui-bootstrap-tpls.js'
-			]
-		},
-		css: [
-			'public/modules/**/css/*.css'
-		],
-		js: [
-			'public/config.js',
-			'public/application.js',
+    app: {
+        title: 'MEAN.JS',
+        description: 'Full-Stack JavaScript with MongoDB, Express, AngularJS, and Node.js',
+        keywords: 'mongodb, express, angularjs, node.js, mongoose, passport'
+    },
+    port: process.env.PORT || 3000,
+    templateEngine: 'swig',
+    // The secret should be set to a non-guessable string that
+    // is used to compute a session hash
+    sessionSecret: 'MEAN',
+    // The name of the MongoDB collection to store sessions in
+    sessionCollection: 'sessions',
+    // The session cookie settings
+    sessionCookie: {
+        path: '/',
+        httpOnly: true,
+        // If secure is set to true then it will cause the cookie to be set
+        // only when SSL-enabled (HTTPS) is used, and otherwise it won't
+        // set a cookie. 'true' is recommended yet it requires the above
+        // mentioned pre-requisite.
+        secure: false,
+        // Only set the maxAge to null if the cookie shouldn't be expired
+        // at all. The cookie will expunge when the browser is closed.
+        maxAge: null,
+        // To set the cookie in a specific domain uncomment the following
+        // setting:
+        // domain: 'yourdomain.com'
+    },
+    // The session cookie name
+    sessionName: 'connect.sid',
+    log: {
+        // Can specify one of 'combined', 'common', 'dev', 'short', 'tiny'
+        format: 'combined',
+        // Stream defaults to process.stdout
+        // Uncomment to enable logging to a log on the file system
+        options: {
+            stream: 'access.log'
+        }
+    },
+    assets: {
+        lib: {
+            css: [
+                'public/lib/bootstrap/dist/css/bootstrap.css',
+                'public/lib/bootstrap/dist/css/bootstrap-theme.css',
+            ],
+            js: [
+                'public/lib/angular/angular.js',
+                'public/lib/angular-resource/angular-resource.js',
+                'public/lib/angular-animate/angular-animate.js',
+                'public/lib/angular-ui-router/release/angular-ui-router.js',
+                'public/lib/angular-ui-utils/ui-utils.js',
+                'public/lib/angular-bootstrap/ui-bootstrap-tpls.js'
+            ]
+        },
+        css: [
+            'public/modules/**/css/*.css'
+        ],
+        js: [
+            'public/config.js',
+            'public/application.js',
             'public/modules/*/*.module.js',
             'public/modules/*/services/*.js',
-			'public/modules/*/*.js',
-			'public/modules/*/*[!tests]*/*.js'
-		],
-		tests: [
-			'public/lib/angular-mocks/angular-mocks.js',
-			'public/modules/*/tests/*.js'
-		]
-	}
+            'public/modules/*/*.js',
+            'public/modules/*/*[!tests]*/*.js'
+        ],
+        tests: [
+            'public/lib/angular-mocks/angular-mocks.js',
+            'public/modules/*/tests/*.js'
+        ]
+    }
 };

--- a/config/env/all.js
+++ b/config/env/all.js
@@ -1,74 +1,74 @@
 'use strict';
 
 module.exports = {
-    app: {
-        title: 'MEAN.JS',
-        description: 'Full-Stack JavaScript with MongoDB, Express, AngularJS, and Node.js',
-        keywords: 'mongodb, express, angularjs, node.js, mongoose, passport'
-    },
-    port: process.env.PORT || 3000,
-    templateEngine: 'swig',
-    // The secret should be set to a non-guessable string that
-    // is used to compute a session hash
-    sessionSecret: 'MEAN',
-    // The name of the MongoDB collection to store sessions in
-    sessionCollection: 'sessions',
-    // The session cookie settings
-    sessionCookie: {
-        path: '/',
-        httpOnly: true,
-        // If secure is set to true then it will cause the cookie to be set
-        // only when SSL-enabled (HTTPS) is used, and otherwise it won't
-        // set a cookie. 'true' is recommended yet it requires the above
-        // mentioned pre-requisite.
-        secure: false,
-        // Only set the maxAge to null if the cookie shouldn't be expired
-        // at all. The cookie will expunge when the browser is closed.
-        maxAge: null,
-        // To set the cookie in a specific domain uncomment the following
-        // setting:
-        // domain: 'yourdomain.com'
-    },
-    // The session cookie name
-    sessionName: 'connect.sid',
-    log: {
-        // Can specify one of 'combined', 'common', 'dev', 'short', 'tiny'
-        format: 'combined',
-        // Stream defaults to process.stdout
-        // Uncomment to enable logging to a log on the file system
-        options: {
-            stream: 'access.log'
-        }
-    },
-    assets: {
-        lib: {
-            css: [
-                'public/lib/bootstrap/dist/css/bootstrap.css',
-                'public/lib/bootstrap/dist/css/bootstrap-theme.css',
-            ],
-            js: [
-                'public/lib/angular/angular.js',
-                'public/lib/angular-resource/angular-resource.js',
-                'public/lib/angular-animate/angular-animate.js',
-                'public/lib/angular-ui-router/release/angular-ui-router.js',
-                'public/lib/angular-ui-utils/ui-utils.js',
-                'public/lib/angular-bootstrap/ui-bootstrap-tpls.js'
-            ]
-        },
-        css: [
-            'public/modules/**/css/*.css'
-        ],
-        js: [
-            'public/config.js',
-            'public/application.js',
-            'public/modules/*/*.module.js',
-            'public/modules/*/services/*.js',
-            'public/modules/*/*.js',
-            'public/modules/*/*[!tests]*/*.js'
-        ],
-        tests: [
-            'public/lib/angular-mocks/angular-mocks.js',
-            'public/modules/*/tests/*.js'
-        ]
-    }
+	app: {
+		title: 'MEAN.JS',
+		description: 'Full-Stack JavaScript with MongoDB, Express, AngularJS, and Node.js',
+		keywords: 'mongodb, express, angularjs, node.js, mongoose, passport'
+	},
+	port: process.env.PORT || 3000,
+	templateEngine: 'swig',
+	// The secret should be set to a non-guessable string that
+	// is used to compute a session hash
+	sessionSecret: 'MEAN',
+	// The name of the MongoDB collection to store sessions in
+	sessionCollection: 'sessions',
+	// The session cookie settings
+	sessionCookie: {
+		path: '/',
+		httpOnly: true,
+		// If secure is set to true then it will cause the cookie to be set
+		// only when SSL-enabled (HTTPS) is used, and otherwise it won't
+		// set a cookie. 'true' is recommended yet it requires the above
+		// mentioned pre-requisite.
+		secure: false,
+		// Only set the maxAge to null if the cookie shouldn't be expired
+		// at all. The cookie will expunge when the browser is closed.
+		maxAge: null,
+		// To set the cookie in a specific domain uncomment the following
+		// setting:
+		// domain: 'yourdomain.com'
+	},
+	// The session cookie name
+	sessionName: 'connect.sid',
+	log: {
+		// Can specify one of 'combined', 'common', 'dev', 'short', 'tiny'
+		format: 'combined',
+		// Stream defaults to process.stdout
+		// Uncomment to enable logging to a log on the file system
+		options: {
+			stream: 'access.log'
+		}
+	},
+	assets: {
+		lib: {
+			css: [
+				'public/lib/bootstrap/dist/css/bootstrap.css',
+				'public/lib/bootstrap/dist/css/bootstrap-theme.css',
+			],
+			js: [
+				'public/lib/angular/angular.js',
+				'public/lib/angular-resource/angular-resource.js',
+				'public/lib/angular-animate/angular-animate.js',
+				'public/lib/angular-ui-router/release/angular-ui-router.js',
+				'public/lib/angular-ui-utils/ui-utils.js',
+				'public/lib/angular-bootstrap/ui-bootstrap-tpls.js'
+			]
+		},
+		css: [
+			'public/modules/**/css/*.css'
+		],
+		js: [
+			'public/config.js',
+			'public/application.js',
+			'public/modules/*/*.module.js',
+			'public/modules/*/services/*.js',
+			'public/modules/*/*.js',
+			'public/modules/*/*[!tests]*/*.js'
+		],
+		tests: [
+			'public/lib/angular-mocks/angular-mocks.js',
+			'public/modules/*/tests/*.js'
+		]
+	}
 };


### PR DESCRIPTION
Some Angular providers may be needed at config state. So the services files must be loaded before the other JS files, especially the config ones.

But the `assets.js` object in `config/env/all.js` makes `module.exports.getJavaScriptAssets()` in `config/config.js` load all JS assets alphabetically.

This PR fixes this and makes the JS files being loaded in this order :
1. Angular lib files
2. App config (`public/config.js`)
3. App init  (`public/application.js`)
4. Modules declarations  (`public/modules/*/*.module.js`)
5. Modules services (`public/modules/*/services/*.js`)
6. The remainder...