### PR TITLE
Added controller init

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -33,6 +33,14 @@ module.exports = function(db) {
 		require(path.resolve(modelPath));
 	});
 
+	// Globbing controllers files
+	config.getGlobbedFiles('./app/controllers/*.js').forEach(function(controllerPath) {
+		var controller = require(path.resolve(controllerPath));
+		if('init' in controller) {
+			controller.init(app);
+		}
+	});	
+
 	// Setting application local variables
 	app.locals.title = config.app.title;
 	app.locals.description = config.app.description;


### PR DESCRIPTION
With some projects, I want to load some logic when the server starts. Because I don't want to modify the express.js file too heavily with project specific stuff, I've added globbing of the controllers and a check if that module has an 'init' function. If so, the init function will be executed when the server starts. In this way, you can load stuff when the server starts while the logic stays in the controllers.