### PR TITLE
Provide a fallback and upgrade path for IE6/7/8 users

### DIFF
--- a/app/views/layout.server.view.html
+++ b/app/views/layout.server.view.html
@@ -63,6 +63,15 @@
 	<!--Livereload script rendered -->
 	<script type="text/javascript" src="http://{{request.hostname}}:35729/livereload.js"></script>
 	{% endif %}
+
+	<!--[if lt IE 9]>
+	<section class="browsehappy jumbotron hide">
+		<h1>Hello there!</h1>
+		<p>You are using an old browser which we unfortunately do not support.</p>
+		<p>Please <a href="http://browsehappy.com/">click here</a> to update your browser before using the website.</p>
+		<p><a href="http://browsehappy.com" class="btn btn-primary btn-lg" role="button">Yes, upgrade my browser!</a></p>
+	</section>
+	<![endif]-->
 </body>
 
 </html>

--- a/public/modules/core/css/core.css
+++ b/public/modules/core/css/core.css
@@ -13,3 +13,8 @@
 .ng-valid.ng-dirty {
 	border-color: #78FA89;
 }
+.browsehappy.jumbotron.hide,
+body.ng-cloak
+{
+	display: block;
+}


### PR DESCRIPTION
At the moment, IE6, IE7 and IE8 receive a white screen of death. This pull request displays a friendly error message and provides the user with a link to http://browsehappy.com// so that they can upgrade
