### PR TITLE
Allow the user to configure an instance of elastic search in the app

### DIFF
--- a/config/env/all.js
+++ b/config/env/all.js
@@ -69,4 +69,9 @@ module.exports = {
 			'public/modules/*/tests/*.js'
 		]
 	}
+	// If you have elastic search installed, uncomment this to create an instance on the global.es object
+	// elasticsearch: {
+	// 	host: '127.0.0.1:9200',
+	// 	log: 'warning'
+	// }
 };

--- a/config/init.js
+++ b/config/init.js
@@ -26,6 +26,15 @@ module.exports = function() {
 
 			process.env.NODE_ENV = 'development';
 		}
+
+		// Initialize a single instance of Elastic Search if it is configured, accessible through global.es
+		var config = require('./config');
+		if (config.elasticsearch)
+		{
+			// We are only allowed to initialize a single instance of ES so we are doing this here,
+			// see http://www.elasticsearch.org/guide/en/elasticsearch/client/javascript-api/current/configuration.html#_config_options
+			global.es = new require('elasticsearch').elasticsearch.Client(config.elasticsearch);
+		}
 	});
 
 };


### PR DESCRIPTION
Optionally, if a config.elasticsearch is configured, we can instantiate a global object with a connection to Elastic Search to be used for indexing/querying.