### PR TITLE
Adding --smallfile command to fig.yml to fix mongo start problem when use docker fig

### DIFF
--- a/app/views/index.server.view.html
+++ b/app/views/index.server.view.html
@@ -2,4 +2,5 @@
 
 {% block content %}
 	<section data-ui-view></section>
+	test
 {% endblock %}

--- a/app/views/index.server.view.html
+++ b/app/views/index.server.view.html
@@ -1,6 +1,5 @@
 {% extends 'layout.server.view.html' %}
 
 {% block content %}
-	<section data-ui-view></section>
-	test
+	<section data-ui-view></section>	
 {% endblock %}

--- a/fig.yml
+++ b/fig.yml
@@ -8,5 +8,6 @@ web:
    NODE_ENV: development
 db:
   image: mongo
+  command: --smallfiles
   ports: 
    - "27017:27017"


### PR DESCRIPTION
Adding --smallfile command to fig.yml, to fix "Insufficient free space for journal files" when use docker
related to this issue https://github.com/dockerfile/mongodb/issues/9

