### PR TITLE
cleaning up css and js assets 

### DIFF
--- a/app/views/layout.server.view.html
+++ b/app/views/layout.server.view.html
@@ -35,7 +35,8 @@
 	<link href="/modules/core/img/brand/favicon.ico" rel="shortcut icon" type="image/x-icon">
 
 	<!--Application CSS Files-->
-	{% for cssFile in cssFiles %}<link rel="stylesheet" href="{{cssFile}}">{% endfor %}
+	{% for cssFile in cssFiles %}
+		<link rel="stylesheet" href="{{cssFile}}">{% endfor %}
 
 	<!-- HTML5 Shim -->
 	<!--[if lt IE 9]>
@@ -57,7 +58,8 @@
 	</script>
 
 	<!--Application JavaScript Files-->
-	{% for jsFile in jsFiles %}<script type="text/javascript" src="{{jsFile}}"></script>{% endfor %} 
+	{% for jsFile in jsFiles %}
+		<script type="text/javascript" src="{{jsFile}}"></script>{% endfor %} 
 
 	{% if process.env.NODE_ENV === 'development' %}
 	<!--Livereload script rendered -->


### PR DESCRIPTION
cleaning up css and js assets so they look indented and easy to read on browsers when viewing the HTML source of the page

before:
![assets_clearview1](https://cloud.githubusercontent.com/assets/316371/5777078/16c1ebb6-9d98-11e4-95b4-33065d7ec4e2.PNG)

after:
![assets_clearview2](https://cloud.githubusercontent.com/assets/316371/5777079/1b7a333e-9d98-11e4-890c-26edadf3ae75.PNG)
