### PR TITLE
Infer first and last name from github and twitter response

### DIFF
--- a/config/strategies/github.js
+++ b/config/strategies/github.js
@@ -23,8 +23,15 @@ module.exports = function() {
 			providerData.refreshToken = refreshToken;
 
 			// Create the user OAuth profile
+			var displayName = profile.displayName.trim();
+			var iSpace = displayName.indexOf(' '); // index of the whitespace following the firstName
+			var firstName =  iSpace !== -1 ? displayName.substring(0, iSpace) : displayName;
+			var lastName = iSpace !== -1 ? displayName.substring(iSpace + 1) : '';
+
 			var providerUserProfile = {
-				displayName: profile.displayName,
+				firstName: firstName,
+				lastName: lastName,
+				displayName: displayName,
 				email: profile.emails[0].value,
 				username: profile.username,
 				provider: 'github',

--- a/config/strategies/twitter.js
+++ b/config/strategies/twitter.js
@@ -23,8 +23,15 @@ module.exports = function() {
 			providerData.tokenSecret = tokenSecret;
 
 			// Create the user OAuth profile
+			var displayName = profile.displayName.trim();
+			var iSpace = displayName.indexOf(' '); // index of the whitespace following the firstName
+			var firstName =  iSpace !== -1 ? displayName.substring(0, iSpace) : displayName;
+			var lastName = iSpace !== -1 ? displayName.substring(iSpace + 1) : '';
+
 			var providerUserProfile = {
-				displayName: profile.displayName,
+				firstName: firstName,
+				lastName: lastName,
+				displayName: displayName,
 				username: profile.username,
 				provider: 'twitter',
 				providerIdentifierField: 'id_str',


### PR DESCRIPTION
I think `firstName` and `lastName` should be set when signing through providers. This fixes it for github and twitter.