### PR TITLE
Support publishing RabbitMQ msgs via global.publishEvent

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -8,6 +8,10 @@ module.exports = {
 			pass: ''
 		}
 	},
+	rabbit: {
+		hostname: 'localhost',
+		queue: 'meanjs'
+	},
 	log: {
 		// Can specify one of 'combined', 'common', 'dev', 'short', 'tiny'
 		format: 'dev',

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
 		"glob": "~4.0.5",
 		"async": "~0.9.0",
 		"nodemailer": "~1.3.0",
-		"chalk": "~0.5"
+		"chalk": "~0.5",
+		"amqp": "^0.2.0"
 	},
 	"devDependencies": {
 		"supertest": "~0.14.0",

--- a/server.js
+++ b/server.js
@@ -43,6 +43,10 @@ console.log(chalk.green(config.app.title + ' application started'));
 console.log(chalk.green('Environment:\t\t\t' + process.env.NODE_ENV));
 console.log(chalk.green('Port:\t\t\t\t' + config.port));
 console.log(chalk.green('Database:\t\t\t' + config.db.uri));
+if (process.env.USE_RABBIT === 'true') {
+	console.log(chalk.green('Rabbit Hostname:\t\t' + config.rabbit.hostname));
+	console.log(chalk.green('Rabbit Queue:\t\t\t' + config.rabbit.queue));
+}
 if (process.env.NODE_ENV === 'secure') {
 	console.log(chalk.green('HTTPs:\t\t\t\ton'));
 }


### PR DESCRIPTION
Hi,

This patch would allow publishing RabbitMQ msgs via global.publishEvent(msg) when USE_RABBIT = true.

Users who do not care about RabbitMQ would not have their workflow changed in any way.

I am not crazy about polluting the global namespace but I think the ability to publish msgs from anywhere is very attractive.

A msg is published when node starts:
global.publishEvent({
				type : 'node started',
				version : process.versions.v8,
				filename : __filename
			});

A msg subscriber for instance can check the node version and make sure that no known security vulnerabilities exist.

Other use cases include publishing all errors, state transitions, or anything else that is potentially interesting to other pieces in your macro system.

Python example of pulling out the msg:
#!/usr/bin/env python
import pika
RABBIT_HOST = 'localhost'
RABBIT_QUEUE = 'meanjs'

connection = pika.BlockingConnection(pika.ConnectionParameters(host = RABBIT_HOST))
channel = connection.channel()

channel.queue_declare(queue = RABBIT_QUEUE)

print ' [*] Waiting for messages. To exit press CTRL+C'

def callback(ch, method, properties, body):
    print " [x] Received %r" % (body,)

channel.basic_consume(callback,
                      queue=RABBIT_QUEUE,
                      no_ack=True)

channel.start_consuming()

For all this to work, RabbitMQ should be installed on the host.

I can add docs, examples, etc..

Thanks,
-pavel