### PR TITLE
Adding missing envs for docker / fig in development and test

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 	db: {
-		uri: 'mongodb://localhost/mean-dev',
+		uri: 'mongodb://' + (process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost') + '/mean-dev',
 		options: {
 			user: '',
 			pass: ''

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 	db: {
-		uri: 'mongodb://localhost/mean-test',
+		uri: 'mongodb://' + (process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost') + '/mean-test',
 		options: {
 			user: '',
 			pass: ''


### PR DESCRIPTION
Currently the Docker setup only works for ‘production’ environment. Since the default is `development` (See https://github.com/meanjs/mean/blob/master/fig.yml#L8) a `fig up` results in a database connection error.


It mimics the change that has already been merged to `production.js`: https://github.com/meanjs/mean/commit/83686b82d9a126374d3a36f3bb97a511bc11ef85
https://github.com/meanjs/mean/blob/master/config/env/production.js#L5


This PR is an update from #183

It fixes #222, #237, #342, #142
