### PR TITLE
#450 Fix for hanging gulp on mongoose connections being left open

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -119,7 +119,6 @@ gulp.task('mocha', function (done) {
 
 	// Connect mongoose
 	mongoose.connect(function() {
-
 		// Run the tests
 		gulp.src(testAssets.tests.server)
 			.pipe(plugins.mocha({
@@ -128,7 +127,8 @@ gulp.task('mocha', function (done) {
 			.on('error', function (err) {
 				// If an error occurs, save it
 				error = err;
-			}).on('end', function() {
+			})
+			.on('end', function() {
 				// When the tests are done, disconnect mongoose and pass the error state back to gulp
 				mongoose.disconnect(function() {
 					done(error);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -115,16 +115,21 @@ gulp.task('less', function () {
 gulp.task('mocha', function (done) {
 	// Open mongoose connections
 	var mongoose = require('./config/lib/mongoose.js');
-
 	var error;
+
+	// Connect mongoose
 	mongoose.connect(function() {
+
+		// Run the tests
 		gulp.src(testAssets.tests.server)
 			.pipe(plugins.mocha({
 				reporter: 'spec'
 			}))
 			.on('error', function (err) {
-				error = new Error('Mocha tests failed');
+				// If an error occurs, save it
+				error = err;
 			}).on('end', function() {
+				// When the tests are done, disconnect mongoose and pass the error state back to gulp
 				mongoose.disconnect(function(){
 					done(error);
 				});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,7 +130,7 @@ gulp.task('mocha', function (done) {
 				error = err;
 			}).on('end', function() {
 				// When the tests are done, disconnect mongoose and pass the error state back to gulp
-				mongoose.disconnect(function(){
+				mongoose.disconnect(function() {
 					done(error);
 				});
 			});
@@ -155,11 +155,11 @@ gulp.task('webdriver-update', plugins.protractor.webdriver_update);
 gulp.task('protractor', function () {
 	gulp.src([])
 		.pipe(plugins.protractor.protractor({
-			configFile: "protractor.conf.js"
+			configFile: 'protractor.conf.js'
 		}))
 		.on('error', function (e) {
-			throw e
-		})
+			throw e;
+		});
 });
 
 // Lint CSS and JavaScript files.


### PR DESCRIPTION
I updated the gulp build so that the mongoose connect/disconnect take place in the mocha task based on the lifecycle of the stream. This way, we can guarantee that the disconnect function is always called regardless of if the mocha tests fail or not. I'm also sending an error message to the task callback in the event that an error is generated by the tests. This way, gulp will finish in an error state if the tests fail and will finish in an ok state if they pass. I've tested this with passing and failing tests and the gulp build closes correctly now.