### PR TITLE
Upgrade connect-mongo to 0.7.0 to support Mongoose 4.0

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -113,7 +113,7 @@ module.exports.initSession = function (app, db) {
 		resave: true,
 		secret: config.sessionSecret,
 		store: new MongoStore({
-			db: db.connection.db,
+			mongooseConnection: db.connection,
 			collection: config.sessionCollection
 		})
 	}));

--- a/config/lib/socket.io.js
+++ b/config/lib/socket.io.js
@@ -20,7 +20,7 @@ module.exports = function(app, db) {
 
     // Create a MongoDB storage object
     var mongoStore = new MongoStore({
-        db: db.connection.db,
+        mongooseConnection: db.connection,
         collection: config.sessionCollection
     });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -115,13 +115,17 @@ gulp.task('less', function () {
 gulp.task('openMongoose', function (done) {
 	var mongoose = require('./config/lib/mongoose.js');
 
-	mongoose.connect(done);
+	mongoose.connect(function() {
+		done();
+	});
 });
 
 gulp.task('closeMongoose', function (done) {
 	var mongoose = require('./config/lib/mongoose.js');
 
-	mongoose.disconnect(done);
+	mongoose.disconnect(function(err) {
+		done(err);
+	});
 });
 
 // Mocha tests task

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -115,15 +115,13 @@ gulp.task('less', function () {
 gulp.task('openMongoose', function (done) {
 	var mongoose = require('./config/lib/mongoose.js');
 
-	mongoose.connect(function(db) {
-		done();
-	});
+	mongoose.connect(done);
 });
 
 gulp.task('closeMongoose', function (done) {
 	var mongoose = require('./config/lib/mongoose.js');
 
-	mongoose.disconnect();
+	mongoose.disconnect(done);
 });
 
 // Mocha tests task

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"method-override": "~2.3.0",
 		"morgan": "~1.4.1",
 		"multer": "0.1.6",
-		"connect-mongo": "~0.4.1",
+		"connect-mongo": "~0.7.0",
 		"connect-flash": "~0.1.1",
 		"helmet": "~0.4.0",
 		"consolidate": "~0.10.0",


### PR DESCRIPTION
Upgraded connect-mongo to 0.7.0, old version (0.4.1) does work with Mongoose 4.0.0-rc3. 

API for reusing Mongoose connection has changed, for that resason config/lib/express.js and config/lib/socket.io.js are updated. 