### PR TITLE
Enable redirection to previous page after login

### DIFF
--- a/modules/core/client/app/init.js
+++ b/modules/core/client/app/init.js
@@ -32,6 +32,14 @@ angular.module(ApplicationConfiguration.applicationModuleName).run(function($roo
             }
         }
     });
+    // Record previous state
+    $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams) {
+        $state.previous = {
+            state: fromState,
+            params: fromParams,
+            href: $state.href(fromState, fromParams)
+        };
+    });
 });
 
 //Then define the init function for starting up the application

--- a/modules/users/client/controllers/authentication.client.controller.js
+++ b/modules/users/client/controllers/authentication.client.controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
-angular.module('users').controller('AuthenticationController', ['$scope', '$http', '$location', 'Authentication',
-	function($scope, $http, $location, Authentication) {
+angular.module('users').controller('AuthenticationController', ['$scope', '$state', '$http', '$location', '$window', 'Authentication',
+	function($scope, $state, $http, $location, $window, Authentication) {
 		$scope.authentication = Authentication;
 
 		// Get an eventual error defined in the URL query string:
@@ -15,8 +15,8 @@ angular.module('users').controller('AuthenticationController', ['$scope', '$http
 				// If successful we assign the response to the global user model
 				$scope.authentication.user = response;
 
-				// And redirect to the index page
-				$location.path('/');
+				// And redirect to the previous or home page
+				$state.go($state.previous.state.name || 'home', $state.previous.params);
 			}).error(function(response) {
 				$scope.error = response.message;
 			});
@@ -27,11 +27,23 @@ angular.module('users').controller('AuthenticationController', ['$scope', '$http
 				// If successful we assign the response to the global user model
 				$scope.authentication.user = response;
 
-				// And redirect to the index page
-				$location.path('/');
+				// And redirect to the previous or home page
+				$state.go($state.previous.state.name  || 'home', $state.previous.params);
 			}).error(function(response) {
 				$scope.error = response.message;
 			});
+		};
+
+		// OAuth provider request
+		$scope.callOauthProvider = function(url) {
+			var redirect_to;
+
+			if ($state.previous) {
+				redirect_to = $state.previous.href;
+			}
+
+			// Effectively call OAuth authentication route:
+			$window.location.href = url + (redirect_to ? '?redirect_to=' + encodeURIComponent(redirect_to) : '');
 		};
 	}
 ]);

--- a/modules/users/client/views/authentication/authentication.client.view.html
+++ b/modules/users/client/views/authentication/authentication.client.view.html
@@ -1,24 +1,12 @@
-<section class="row">
+<section class="row" data-ng-controller="AuthenticationController">
 	<h3 class="col-md-12 text-center">Sign in using your social accounts</h3>
 	<div class="col-md-12 text-center">
-		<a href="/api/auth/facebook" target="_self" class="undecorated-link">
-			<img src="/modules/users/img/buttons/facebook.png">
-		</a>
-		<a href="/api/auth/twitter" target="_self" class="undecorated-link">
-			<img src="/modules/users/img/buttons/twitter.png">
-		</a>
-		<a href="/api/auth/google" target="_self" class="undecorated-link">
-			<img src="/modules/users/img/buttons/google.png">
-		</a>
-		<a href="/api/auth/linkedin" target="_self" class="undecorated-link">
-			<img src="/modules/users/img/buttons/linkedin.png">
-		</a>
-		<a href="/api/auth/github" target="_self" class="undecorated-link">
-			<img src="/modules/users/img/buttons/github.png">
-		</a>
-		<a href="/api/auth/paypal" target="_self" class="undecorated-link">
-			<img src="/modules/users/img/buttons/paypal.png">
-		</a>
+		<img ng-click="callOauthProvider('/api/auth/facebook')" ng-src="/modules/users/img/buttons/facebook.png">
+		<img ng-click="callOauthProvider('/api/auth/twitter')" ng-src="/modules/users/img/buttons/twitter.png">
+		<img ng-click="callOauthProvider('/api/auth/google')" ng-src="/modules/users/img/buttons/google.png">
+		<img ng-click="callOauthProvider('/api/auth/linkedin')" ng-src="/modules/users/img/buttons/linkedin.png">
+		<img ng-click="callOauthProvider('/api/auth/github')" ng-src="/modules/users/img/buttons/github.png">
+		<img ng-click="callOauthProvider('/api/auth/paypal')"  ng-src="/modules/users/img/buttons/paypal.png">
 	</div>
 	<div ui-view></div>
 </section>

--- a/modules/users/server/routes/auth.server.routes.js
+++ b/modules/users/server/routes/auth.server.routes.js
@@ -20,17 +20,17 @@ module.exports = function(app) {
 	app.route('/api/auth/signout').get(users.signout);
 
 	// Setting the facebook oauth routes
-	app.route('/api/auth/facebook').get(passport.authenticate('facebook', {
+	app.route('/api/auth/facebook').get(users.oauthCall('facebook', {
 		scope: ['email']
 	}));
 	app.route('/api/auth/facebook/callback').get(users.oauthCallback('facebook'));
 
 	// Setting the twitter oauth routes
-	app.route('/api/auth/twitter').get(passport.authenticate('twitter'));
+	app.route('/api/auth/twitter').get(users.oauthCall('twitter'));
 	app.route('/api/auth/twitter/callback').get(users.oauthCallback('twitter'));
 
 	// Setting the google oauth routes
-	app.route('/api/auth/google').get(passport.authenticate('google', {
+	app.route('/api/auth/google').get(users.oauthCall('google', {
 		scope: [
 			'https://www.googleapis.com/auth/userinfo.profile',
 			'https://www.googleapis.com/auth/userinfo.email'
@@ -39,7 +39,7 @@ module.exports = function(app) {
 	app.route('/api/auth/google/callback').get(users.oauthCallback('google'));
 
 	// Setting the linkedin oauth routes
-	app.route('/api/auth/linkedin').get(passport.authenticate('linkedin', {
+	app.route('/api/auth/linkedin').get(users.oauthCall('linkedin', {
 		scope: [
 			'r_basicprofile',
 			'r_emailaddress'
@@ -48,10 +48,10 @@ module.exports = function(app) {
 	app.route('/api/auth/linkedin/callback').get(users.oauthCallback('linkedin'));
 
 	// Setting the github oauth routes
-	app.route('/api/auth/github').get(passport.authenticate('github'));
+	app.route('/api/auth/github').get(users.oauthCall('github'));
 	app.route('/api/auth/github/callback').get(users.oauthCallback('github'));
 
 	// Setting the paypal oauth routes
-	app.route('/api/auth/paypal').get(passport.authenticate('paypal'));
+	app.route('/api/auth/paypal').get(users.oauthCall('paypal'));
 	app.route('/api/auth/paypal/callback').get(users.oauthCallback('paypal'));
 };


### PR DESCRIPTION
In response to #185

Two different strategies are adopted, one for when the user authenticates locally and the other through providers. When authenticating locally, the signin function in the client controller redirects to the previous state (storing and using a state name) after successful login. When authenticating through a provider, the first call to provider stores the previous URL (not state, URL) in the session. Then, when provider actually calls the authentication callback, session `redirect_to` path is used for redirecting user.

Note: I originally did this to master, so there is one extra thing to correct. First, note on branch master sign-in and signup are not nested states. Given they are nested in 0.4.0, the controller instantiated in the nested state does not capture the previous state properly. Therefore, this commit is not redirecting when authenticating locally yet. Suggestions are welcome.

For example, it seems an ugly solution to instantiate `AuthenticationController` both at parent and nested states. What would be better?