### PR TITLE
Fix headers to HTML5 format

### DIFF
--- a/modules/core/server/views/layout.server.view.html
+++ b/modules/core/server/views/layout.server.view.html
@@ -1,15 +1,14 @@
 <!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en">
 
 <head>
 	<title>{{title}}</title>
 
 	<!-- General META -->
 	<meta charset="utf-8">
-	<meta http-equiv="Content-type" content="text/html;charset=UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-	<meta name="fragment" content="!" />
-	<base href="/"/>
+	<meta name="fragment" content="!">
+	<base href="/">
 
 	<!-- Responsive META -->
 	<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1">


### PR DESCRIPTION
Headers were a weird mixture of html5 and xhtml. Now it's pure html5.


Use this as doctype if you really want it to be xhtml, but I don't see why would you want that with Angular:
```html
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
```