### PR TITLE
Change the way Express gets hostname

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -35,7 +35,7 @@ module.exports.initLocalVariables = function (app) {
 
 	// Passing the request url to environment locals
 	app.use(function (req, res, next) {
-		res.locals.host = req.protocol + '://' + req.hostname;
+		res.locals.host = req.protocol + '://' + req.get('host');
 		res.locals.url = req.protocol + '://' + req.headers.host + req.originalUrl;
 		next();
 	});


### PR DESCRIPTION
Getting host via req.get('host') instead of req.hostname. 

get() methods adds also port if it's something else than 80.

Otherwise links that should be "localhost:3000" end up being just "localhost".