### PR TITLE
Ignore ALL .log files at gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 .nodemonignore
 .sass-cache/
-npm-debug.log
 node_modules/
 public/lib/
 public/dist/
@@ -9,3 +8,4 @@ public/dist/
 .idea/
 uploads
 modules/users/client/img/profile/uploads
+*.log


### PR DESCRIPTION
Smart practise. 

E.g. when app is served with Phusion Passenger or some other app server, you might end up having some log files at the root folder.