### PR TITLE
dockerfile/nodejs has been merged to official repo node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/nodejs
+FROM node
 
 MAINTAINER Matthias Luebken, matthias@catalyst-zero.com
 


### PR DESCRIPTION
I tried to get started with the docker file and kept getting Error: image dockerfile/nodejs:latest not found

After some digging, looks like it has been merged to: https://registry.hub.docker.com/_/node/

I can't even go to the old https://registry.hub.docker.com/u/dockerfiles/nodejs.

Sorry if this is wrong, first commit using docker in sometime. 