### PR TITLE
Update grunt-nodemon, livereload only when server has restarted.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ public/lib/
 app/tests/coverage/
 .bower-*/
 .idea/
+.rebooted
 
 # MEAN.js app and assets
 # ======================

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -16,11 +16,11 @@ module.exports = function(grunt) {
 		pkg: grunt.file.readJSON('package.json'),
 		watch: {
 			server: {
-                files: ['.rebooted'],
-                options: {
-                    livereload: true
-                }
-            },
+				files: ['.rebooted'],
+					options: {
+					livereload: true
+				}
+			},
 			clientViews: {
 				files: watchFiles.clientViews,
 				options: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -15,19 +15,12 @@ module.exports = function(grunt) {
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
 		watch: {
-			serverViews: {
-				files: watchFiles.serverViews,
-				options: {
-					livereload: true
-				}
-			},
-			serverJS: {
-				files: watchFiles.serverJS,
-				tasks: ['jshint'],
-				options: {
-					livereload: true
-				}
-			},
+			server: {
+                files: ['.rebooted'],
+                options: {
+                    livereload: true
+                }
+            },
 			clientViews: {
 				files: watchFiles.clientViews,
 				options: {
@@ -92,7 +85,14 @@ module.exports = function(grunt) {
 				options: {
 					nodeArgs: ['--debug'],
 					ext: 'js,html',
-					watch: watchFiles.serverViews.concat(watchFiles.serverJS)
+					watch: watchFiles.serverViews.concat(watchFiles.serverJS),
+					callback: function (nodemon) {
+						nodemon.on('restart', function () {
+				          	setTimeout(function() {
+				            	require('fs').writeFileSync('.rebooted', 'rebooted');
+				          	}, 1000);
+				        });
+					}
 				}
 			}
 		},

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -88,10 +88,10 @@ module.exports = function(grunt) {
 					watch: watchFiles.serverViews.concat(watchFiles.serverJS),
 					callback: function (nodemon) {
 						nodemon.on('restart', function () {
-				          	setTimeout(function() {
-				            	require('fs').writeFileSync('.rebooted', 'rebooted');
-				          	}, 1000);
-				        });
+							setTimeout(function() {
+								require('fs').writeFileSync('.rebooted', 'rebooted');
+							}, 1000);
+						});
 					}
 				}
 			}

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -15,9 +15,13 @@ module.exports = function(grunt) {
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
 		watch: {
+			serverJS: {
+				files: watchFiles.serverJS,
+				tasks: ['jshint']
+ 			},
 			server: {
 				files: ['.rebooted'],
-					options: {
+				options: {
 					livereload: true
 				}
 			},

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"grunt-ng-annotate": "~0.4.0",
 		"grunt-contrib-uglify": "~0.6.0",
 		"grunt-contrib-cssmin": "~0.10.0",
-		"grunt-nodemon": "~0.3.0",
+		"grunt-nodemon": "~0.4.0",
 		"grunt-concurrent": "~1.0.0",
 		"grunt-mocha-test": "~0.12.1",
 		"grunt-karma": "~0.9.0",


### PR DESCRIPTION
When a change is detected on server JS and HTML files, grunt-watch livereload the site but nodemon also restart the server and cause white screen on web browser. 
The grunt-nodemon readme contains an exemple to create a ".rebooted" file that change when the server has restarted. Then livereload will be executed by watching only the ".rebooted" file.