### PR TITLE
Update grunt-nodemon and livereload only when server has restarted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ public/dist/
 .idea/
 uploads
 modules/users/client/img/profile/uploads
+.rebooted

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -23,18 +23,15 @@ module.exports = function (grunt) {
 			}
 		},
 		watch: {
-			serverViews: {
-				files: defaultAssets.server.views,
+			server: {
+				files: ['.rebooted'],
 				options: {
 					livereload: true
 				}
 			},
 			serverJS: {
 				files: defaultAssets.server.allJS,
-				tasks: ['jshint'],
-				options: {
-					livereload: true
-				}
+				tasks: ['jshint']
 			},
 			clientViews: {
 				files: defaultAssets.client.views,
@@ -77,7 +74,14 @@ module.exports = function (grunt) {
 				options: {
 					nodeArgs: ['--debug'],
 					ext: 'js,html',
-					watch: _.union(defaultAssets.server.views, defaultAssets.server.allJS, defaultAssets.server.config)
+					watch: _.union(defaultAssets.server.views, defaultAssets.server.allJS, defaultAssets.server.config),
+					callback: function (nodemon) {
+						nodemon.on('restart', function () {
+							setTimeout(function() {
+								require('fs').writeFileSync('.rebooted', 'rebooted');
+							}, 1000);
+						});
+					}
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"grunt-ng-annotate": "~0.4.0",
 		"grunt-contrib-uglify": "~0.6.0",
 		"grunt-contrib-cssmin": "~0.10.0",
-		"grunt-nodemon": "~0.3.0",
+		"grunt-nodemon": "~0.4.0",
 		"grunt-concurrent": "~1.0.0",
 		"grunt-mocha-test": "~0.12.1",
 		"grunt-karma": "~0.9.0",


### PR DESCRIPTION
When a change is detected on server JS and HTML files, grunt-watch livereload the site but nodemon also restart the server and cause white screen on web browser. 
The grunt-nodemon readme contains an exemple to create a ".rebooted" file that change when the server has restarted. Then livereload will be executed by watching only the ".rebooted" file.