### PR TITLE
#501 Handle 404 errors at Express backend and at Angular frontend

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -177,7 +177,6 @@ module.exports.initModulesServerRoutes = function (app) {
  * Configure error handling
  */
 module.exports.initErrorRoutes = function (app) {
-	// Assume 'not found' in the error msgs is a 404. this is somewhat silly, but valid, you can do whatever you like, set properties, use instanceof etc.
 	app.use(function (err, req, res, next) {
 		// If the error object doesn't exists
 		if (!err) return next();
@@ -187,12 +186,6 @@ module.exports.initErrorRoutes = function (app) {
 
 		// Redirect to error page
 		res.redirect('/server-error');
-	});
-
-	// Assume 404 since no middleware responded
-	app.use(function (req, res) {
-		// Redirect to not found page
-		res.redirect('/not-found');
 	});
 };
 

--- a/modules/core/client/config/core.client.routes.js
+++ b/modules/core/client/config/core.client.routes.js
@@ -3,14 +3,19 @@
 // Setting up route
 angular.module('core').config(['$stateProvider', '$urlRouterProvider',
 	function($stateProvider, $urlRouterProvider) {
-		// Redirect to home view when route not found
-		$urlRouterProvider.otherwise('/');
+
+		// Redirect to 404 when route not found
+		$urlRouterProvider.otherwise('not-found');
 
 		// Home state routing
 		$stateProvider.
-		state('home', {
-			url: '/',
-			templateUrl: 'modules/core/views/home.client.view.html'
-		});
+			state('home', {
+				url: '/',
+				templateUrl: 'modules/core/views/home.client.view.html'
+			}).
+			state('not-found', {
+				url: '/not-found',
+				templateUrl: 'modules/core/views/404.client.view.html'
+			});
 	}
 ]);

--- a/modules/core/client/views/404.client.view.html
+++ b/modules/core/client/views/404.client.view.html
@@ -1,10 +1,6 @@
-{% extends 'layout.server.view.html' %}
-
-{% block content %}
 <h1>Page Not Found</h1>
 <div class="alert alert-danger" role="alert">
 	<span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
 	<span class="sr-only">Error:</span>
-	{{url}} is not a valid path.
+	Page Not Found
 </div>
-{% endblock %}

--- a/modules/core/server/controllers/core.server.controller.js
+++ b/modules/core/server/controllers/core.server.controller.js
@@ -24,9 +24,7 @@ exports.renderServerError = function(req, res) {
  */
 exports.renderNotFound = function(req, res) {
 
-	res
-		.status(404)
-		.format({
+	res.status(404).format({
 			'text/html': function(){
 				res.render('modules/core/server/views/404', {
 					url: req.originalUrl

--- a/modules/core/server/controllers/core.server.controller.js
+++ b/modules/core/server/controllers/core.server.controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Render the main applicaion page
+ * Render the main application page
  */
 exports.renderIndex = function(req, res) {
 	res.render('modules/core/server/views/index', {
@@ -19,10 +19,25 @@ exports.renderServerError = function(req, res) {
 };
 
 /**
- * Render the server not found page
+ * Render the server not found responses
  */
 exports.renderNotFound = function(req, res) {
-	res.status(404).render('modules/core/server/views/404', {
-		url: req.originalUrl
-	});
+	res.status(404);
+
+	// Respond with html page
+	if (req.accepts('html')) {
+		res.render('modules/core/server/views/404', {
+			url: req.originalUrl
+		});
+		return;
+	}
+
+	// Respond with json to API calls
+	if (req.accepts('json')) {
+		res.json({ error: 'Path not found' });
+		return;
+	}
+
+	// Default to plain-text
+	res.type('txt').send('Path not found');
 };

--- a/modules/core/server/controllers/core.server.controller.js
+++ b/modules/core/server/controllers/core.server.controller.js
@@ -20,24 +20,23 @@ exports.renderServerError = function(req, res) {
 
 /**
  * Render the server not found responses
+ * Performs content-negotiation on the Accept HTTP header
  */
 exports.renderNotFound = function(req, res) {
-	res.status(404);
 
-	// Respond with html page
-	if (req.accepts('html')) {
-		res.render('modules/core/server/views/404', {
-			url: req.originalUrl
+	res
+		.status(404)
+		.format({
+			'text/html': function(){
+				res.render('modules/core/server/views/404', {
+					url: req.originalUrl
+				});
+			},
+			'application/json': function(){
+				res.json({ error: 'Path not found' });
+			},
+			'default': function(){
+				res.send('Path not found');
+			}
 		});
-		return;
-	}
-
-	// Respond with json to API calls
-	if (req.accepts('json')) {
-		res.json({ error: 'Path not found' });
-		return;
-	}
-
-	// Default to plain-text
-	res.type('txt').send('Path not found');
 };

--- a/modules/core/server/routes/core.server.routes.js
+++ b/modules/core/server/routes/core.server.routes.js
@@ -6,7 +6,9 @@ module.exports = function(app) {
 
 	// Define error pages
 	app.route('/server-error').get(core.renderServerError);
-	app.route('/not-found').get(core.renderNotFound);
+
+	// Return a 404 for all undefined api, module or lib routes
+	app.route('/:url(api|modules|lib)/*').get(core.renderNotFound);
 
 	// Define application route
 	app.route('/*').get(core.renderIndex);


### PR DESCRIPTION
- `/{api|modules|lib}/*` returns an error page when path doesn’t exist
(from Express).
- `/*` always returns index (from Express), but if `$state` doesn’t
exist, Angular redirects to `/not-found` (no 404 status in that case
though!)
- If `Accept: application/json` header is present without `Accept:
text/html`, return error as json. Hence looking at non existing /api/*
paths with browser would show html error, but querying them with script
would return json.
- Slightly prettier 404 error

Test:
```bash
curl http://localhost:3000/api/notfound -4 -H "Accept: application/json"
```
=> json error.

```bash
curl http://localhost:3000/api/notfound -4 -H "Accept:
text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0
.8"
```
=> html error (imitates Chrome’s Accept header).

Starting point was @dotch’s PL: https://github.com/meanjs/mean/pull/503