### PR TITLE
Add some abstraction to local strategy login error

### DIFF
--- a/modules/users/server/config/strategies/local.js
+++ b/modules/users/server/config/strategies/local.js
@@ -20,14 +20,9 @@ module.exports = function() {
 				if (err) {
 					return done(err);
 				}
-				if (!user) {
+				if (!user || !user.authenticate(password)) {
 					return done(null, false, {
-						message: 'Unknown user'
-					});
-				}
-				if (!user.authenticate(password)) {
-					return done(null, false, {
-						message: 'Invalid password'
+						message: 'Invalid username or password'
 					});
 				}
 


### PR DESCRIPTION
This is implemented in master but it is not in 0.4.0.

This basically prevents username enumeration by providing the same error message when the username doesn't exist or when the username/password combination is wrong.