### PR TITLE
Fix deprecated ExpressJS req.param('provider')

### DIFF
--- a/modules/users/server/controllers/users/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users/users.authentication.server.controller.js
@@ -177,7 +177,7 @@ exports.saveOAuthUserProfile = function(req, providerUserProfile, done) {
  */
 exports.removeOAuthProvider = function(req, res, next) {
 	var user = req.user;
-	var provider = req.param('provider');
+	var provider = req.params.provider;
 
 	if (user && provider) {
 		// Delete the additional provider


### PR DESCRIPTION
>"Deprecated. Use either req.params, req.body or req.query, as applicable."
http://expressjs.com/api.html#req.param