### PR TITLE
Remove targets on signin and signup anchors

### DIFF
--- a/modules/core/client/views/header.client.view.html
+++ b/modules/core/client/views/header.client.view.html
@@ -25,11 +25,11 @@
 		</ul>
 		<ul class="nav navbar-nav navbar-right" data-ng-hide="authentication.user">
 			<li data-ui-sref-active="active">
-				<a data-ui-sref="authentication.signup" target="_self">Sign Up</a>
+				<a data-ui-sref="authentication.signup">Sign Up</a>
 			</li>
 			<li class="divider-vertical"></li>
 			<li data-ui-sref-active="active">
-				<a data-ui-sref="authentication.signin" target="_self">Sign In</a>
+				<a data-ui-sref="authentication.signin">Sign In</a>
 			</li>
 		</ul>
 		<ul class="nav navbar-nav navbar-right" data-ng-show="authentication.user">


### PR DESCRIPTION
Removing target on signin and signup anchors to prevent a complete page reload when changing to those states.