### PR TITLE
Removed the s at 'express routes' in the menu to match the usage of t…

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -125,7 +125,7 @@
 								<a href="#express-controller">Express Controller</a>
 							</li>
 							<li>
-								<a href="#express-routes">Express Routes</a>
+								<a href="#express-routes">Express Route</a>
 							</li>
 							<li>
 								<a href="#express-test">Express Test</a>


### PR DESCRIPTION
…he generator

the generator use

    yo meanjs:express-route <route-name>

and not

    yo meanjs:express-routes <route-name>

So it is logical to do the same in the left menu in gh-pages