### PR TITLE
Remove duplicate assets definition

### DIFF
--- a/config/env/production.js
+++ b/config/env/production.js
@@ -19,24 +19,6 @@ module.exports = {
 			stream: 'access.log'
 		}
 	},
-	assets: {
-		lib: {
-			css: [
-				'public/lib/bootstrap/dist/css/bootstrap.min.css',
-				'public/lib/bootstrap/dist/css/bootstrap-theme.min.css',
-			],
-			js: [
-				'public/lib/angular/angular.min.js',
-				'public/lib/angular-resource/angular-resource.min.js',
-				'public/lib/angular-animate/angular-animate.min.js',
-				'public/lib/angular-ui-router/release/angular-ui-router.min.js',
-				'public/lib/angular-ui-utils/ui-utils.min.js',
-				'public/lib/angular-bootstrap/ui-bootstrap-tpls.min.js'
-			]
-		},
-		css: 'public/dist/application.min.css',
-		js: 'public/dist/application.min.js'
-	},
 	facebook: {
 		clientID: process.env.FACEBOOK_ID || 'APP_ID',
 		clientSecret: process.env.FACEBOOK_SECRET || 'APP_SECRET',


### PR DESCRIPTION
Looks like this sneaked in during the merge with master. Not sure why it would be needed since we have the assets file.