### PR TITLE
cleaning up application startup information

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -61,8 +61,6 @@ var validateEnvironmentVariable = function() {
             console.error(chalk.red('NODE_ENV is not defined! Using default development environment'));
         }
         process.env.NODE_ENV = 'development';
-    } else {
-        console.log(chalk.bold('Application loaded using the "' + process.env.NODE_ENV + '" environment configuration'));
     }
     // Reset console color
     console.log(chalk.white(''));

--- a/server.js
+++ b/server.js
@@ -23,10 +23,10 @@ mongoose.connect(function (db) {
 
 	// Logging initialization
 	console.log('--');
-	console.log(chalk.green(config.app.title + ' application started'));
+	console.log(chalk.green(config.app.title));
 	console.log(chalk.green('Environment:\t\t\t' + process.env.NODE_ENV));
 	console.log(chalk.green('Port:\t\t\t\t' + config.port));
-	console.log(chalk.green('Database:\t\t\t' + config.db.uri));
+	console.log(chalk.green('Database:\t\t\t\t' + config.db.uri));
 	if (process.env.NODE_ENV === 'secure') {
 		console.log(chalk.green('HTTPs:\t\t\t\ton'));
 	}


### PR DESCRIPTION
On starting up the server:
1. Remove the 'application started' suffix to the application title
2. Align the database name tab length
3. Remove the initial 'Application loaded using <NODENEV> environment' as it is anyway reported in the startup info.

Startup information after the fix:
![image](https://cloud.githubusercontent.com/assets/316371/8629688/48769e38-2766-11e5-96e8-86a9a3a64cb3.png)
