### PR TITLE
updated the development.js environment configuration to use mean-dev database

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 	db: {
-		uri: process.env.MONGOHQ_URL || process.env.MONGOLAB_URI || 'mongodb://' + (process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost') + '/mean-test',
+		uri: process.env.MONGOHQ_URL || process.env.MONGOLAB_URI || 'mongodb://' + (process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost') + '/mean-dev',
 		options: {
 			user: '',
 			pass: ''


### PR DESCRIPTION
updated the development.js environment configuration file to use the mean-dev database instead of mean-test which is used for testing/stages environment