### PR TITLE
Fixing user's passwords keep changing when saving the user model

### DIFF
--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -99,7 +99,7 @@ var UserSchema = new Schema({
  * Hook a pre save method to hash the password
  */
 UserSchema.pre('save', function(next) {
-	if (this.password && this.password.length > 6) {
+	if (this.password && this.isModified('password') && this.password.length > 6) {
 		this.salt = crypto.randomBytes(16).toString('base64');
 		this.password = this.hashPassword(this.password);
 	}

--- a/modules/users/tests/server/user.server.model.tests.js
+++ b/modules/users/tests/server/user.server.model.tests.js
@@ -67,6 +67,16 @@ describe('User Model Unit Tests:', function() {
 				done();
 			});
 		});
+
+		it('should confirm that saving user model doesnt change the password', function(done) {
+			user.firstName = 'test';
+			var passwordBefore = user.password;
+			return user.save(function(err) {
+				var passwordAfter = user.password
+				passwordBefore.should.equal(passwordAfter);
+				done();
+			});
+		});
 	});
 
 	after(function(done) {


### PR DESCRIPTION
Addresses issue: https://github.com/meanjs/mean/issues/295
updating the schema save pre hook so that it checks for a modified version of the password field before it tries to re-calculate the new password to save for the user model