### PR TITLE
JSHint test failing because of missing semicolon

### DIFF
--- a/modules/users/tests/server/user.server.model.tests.js
+++ b/modules/users/tests/server/user.server.model.tests.js
@@ -72,7 +72,7 @@ describe('User Model Unit Tests:', function() {
 			user.firstName = 'test';
 			var passwordBefore = user.password;
 			return user.save(function(err) {
-				var passwordAfter = user.password
+				var passwordAfter = user.password;
 				passwordBefore.should.equal(passwordAfter);
 				done();
 			});


### PR DESCRIPTION
I just cloned the branch and both gulp and grunt fail on the lint task because of the missing semicolon.