### PR TITLE
cleaning up code blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,20 @@ The recommended way would be to use the [Official Yo Generator](http://meanjs.or
 
 ### Cloning The GitHub Repository
 You can also use Git to directly clone the MEAN.JS repository:
+
 ```bash
 $ git clone https://github.com/meanjs/mean.git meanjs
 ```
+
 This will clone the latest version of the MEAN.JS repository to a **meanjs** folder.
 
 ### Downloading The Repository Zip File
 Another way to use the MEAN.JS boilerplate is to download a zip copy from the [master branch on GitHub](https://github.com/meanjs/mean/archive/master.zip). You can also do this using `wget` command:
+
 ```bash
 $ wget https://github.com/meanjs/mean/archive/master.zip -O meanjs.zip; unzip meanjs.zip; rm meanjs.zip
 ```
+
 Don't forget to rename **mean-master** after your project name.
 
 ## Quick Install
@@ -78,26 +82,30 @@ Your application should run on port 3000 with the *development* environment conf
 That's it! Your application should be running. To proceed with your development, check the other sections in this documentation.
 If you encounter any problems, try the Troubleshooting section.
 
-* explore ```config/env/development.js``` for development environment configuration options
+* explore `config/env/development.js` for development environment configuration options
 
 ### Running in Production mode
 To run your application with *production* environment configuration, execute grunt as follows:
+
 ```bash
 $ grunt prod
 ```
-* explore ```config/env/production.js``` for production environment configuration options
+
+* explore `config/env/production.js` for production environment configuration options
 
 ### Running with TLS (SSL)
 Application will start by default with secure configuration (SSL mode) turned on and listen on port 8443.
 To run your application in a secure manner you'll need to use OpenSSL and generate a set of self-signed certificates. Unix-based users can use the following command:
+
 ```bash
 $ sh ./scripts/generate-ssl-certs.sh
 ```
+
 Windows users can follow instructions found [here](http://www.websense.com/support/article/kbarticle/How-to-use-OpenSSL-and-Microsoft-Certification-Authority).
 After you've generated the key and certificate, place them in the *config/sslcerts* folder.
 
-Finally, execute grunt's prod task ```grunt prod```
-* enable/disable SSL mode in production environment change the ```secure``` option in ```config/env/production.js```
+Finally, execute grunt's prod task `grunt prod`
+* enable/disable SSL mode in production environment change the `secure` option in `config/env/production.js`
 
 
 ## Testing Your Application


### PR DESCRIPTION
1. Adding spaces between code blocks to text to make it more readable for raw text editors
2. Replacing 3 ticks (`) with just 1 for inline code block notation