### PR TITLE
do not use aes when creating ssl certs to prevent password requirement

### DIFF
--- a/scripts/generate-ssl-certs.sh
+++ b/scripts/generate-ssl-certs.sh
@@ -10,7 +10,7 @@ fi
 
 echo "Generating self-signed certificates..."
 mkdir -p ./config/sslcerts
-openssl genrsa -out ./config/sslcerts/key.pem -aes256 1024
+openssl genrsa -out ./config/sslcerts/key.pem 1024
 openssl req -new -key ./config/sslcerts/key.pem -out ./config/sslcerts/csr.pem
 openssl x509 -req -days 9999 -in ./config/sslcerts/csr.pem -signkey ./config/sslcerts/key.pem -out ./config/sslcerts/cert.pem
 rm ./config/sslcerts/csr.pem


### PR DESCRIPTION
As a developer, I should not use SSL passwords for testing the production environment locally.