### PR TITLE
change _.extend to _.merge

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -147,7 +147,7 @@ var initGlobalConfig = function() {
 	var environmentAssets = require(path.join(process.cwd(), 'config/assets/', process.env.NODE_ENV)) || {};
 
 	// Merge assets
-	var assets = _.extend(defaultAssets, environmentAssets);
+	var assets = _.merge(defaultAssets, environmentAssets);
 
     // Get the default config
     var defaultConfig = require(path.join(process.cwd(), 'config/env/default'));
@@ -156,7 +156,7 @@ var initGlobalConfig = function() {
     var environmentConfig = require(path.join(process.cwd(), 'config/env/', process.env.NODE_ENV)) || {};
 
     // Merge config files
-    var envConf = _.extend(defaultConfig, environmentConfig);
+    var envConf = _.merge(defaultConfig, environmentConfig);
 
    var config = _.merge(envConf, (fs.existsSync(path.join(process.cwd(), 'config/env/local.js')) && require(path.join(process.cwd(), 'config/env/local.js'))) || {});
 


### PR DESCRIPTION
Fixes issue #660 

The _.merge properly merges two objects together. I'm not sure on the exact differences between _.extend and _.merge but they act differently, and _.merge produces the desired results.