### PR TITLE
Task Enhancements

### DIFF
--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -36,7 +36,9 @@ module.exports = {
 		views: ['modules/*/client/views/**/*.html']
 	},
 	server: {
-		allJS: ['gruntfile.js', 'server.js', 'config/**/*.js', 'modules/*/server/**/*.js'],
+		gruntConfig: 'gruntfile.js',
+		gulpConfig: 'gulpfile.js',
+		allJS: ['server.js', 'config/**/*.js', 'modules/*/server/**/*.js'],
 		models: 'modules/*/server/models/**/*.js',
 		routes: ['modules/!(core)/server/routes/**/*.js', 'modules/core/server/routes/**/*.js'],
 		sockets: 'modules/*/server/sockets/**/*.js',

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -31,7 +31,7 @@ module.exports = function (grunt) {
 				}
 			},
 			serverJS: {
-				files: defaultAssets.server.allJS,
+				files: _.union(defaultAssets.server.gruntConfig, defaultAssets.server.allJS),
 				tasks: ['jshint'],
 				options: {
 					livereload: true
@@ -78,7 +78,7 @@ module.exports = function (grunt) {
 				options: {
 					nodeArgs: ['--debug'],
 					ext: 'js,html',
-					watch: _.union(defaultAssets.server.views, defaultAssets.server.allJS, defaultAssets.server.config)
+					watch: _.union(defaultAssets.server.gruntConfig, defaultAssets.server.views, defaultAssets.server.allJS, defaultAssets.server.config)
 				}
 			}
 		},
@@ -91,7 +91,7 @@ module.exports = function (grunt) {
 		},
 		jshint: {
 			all: {
-				src: _.union(defaultAssets.server.allJS, defaultAssets.client.js, testAssets.tests.server, testAssets.tests.client, testAssets.tests.e2e),
+				src: _.union(defaultAssets.server.gruntConfig, defaultAssets.server.allJS, defaultAssets.client.js, testAssets.tests.server, testAssets.tests.client, testAssets.tests.e2e),
 				options: {
 					jshintrc: true,
 					node: true,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,8 @@ var _ = require('lodash'),
 	gulp = require('gulp'),
 	gulpLoadPlugins = require('gulp-load-plugins'),
 	runSequence = require('run-sequence'),
-	plugins = gulpLoadPlugins();
+	plugins = gulpLoadPlugins(),
+	path = require('path');
 
 // Set NODE_ENV to 'test'
 gulp.task('env:test', function () {
@@ -96,8 +97,8 @@ gulp.task('cssmin', function () {
 gulp.task('sass', function () {
 	return gulp.src(defaultAssets.client.sass)
 		.pipe(plugins.sass())
-		.pipe(plugins.rename(function (path) {
-			path.dirname = path.dirname.replace('/scss', '/css');
+		.pipe(plugins.rename(function (file) {
+			file.dirname = file.dirname.replace(path.sep + 'scss', path.sep + 'css');
 		}))
 		.pipe(gulp.dest('./modules/'));
 });
@@ -106,8 +107,8 @@ gulp.task('sass', function () {
 gulp.task('less', function () {
 	return gulp.src(defaultAssets.client.less)
 		.pipe(plugins.less())
-		.pipe(plugins.rename(function (path) {
-			path.dirname = path.dirname.replace('/less', '/css');
+		.pipe(plugins.rename(function (file) {
+			file.dirname = file.dirname.replace(path.sep + 'less', path.sep + 'css');
 		}))
 		.pipe(gulp.dest('./modules/'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,6 +42,7 @@ gulp.task('watch', function() {
 	plugins.livereload.listen();
 
 	// Add watch rules
+	gulp.watch(defaultAssets.server.gulpConfig, ['jshint']);
 	gulp.watch(defaultAssets.server.views).on('change', plugins.livereload.changed);
 	gulp.watch(defaultAssets.server.allJS, ['jshint']).on('change', plugins.livereload.changed);
 	gulp.watch(defaultAssets.client.views).on('change', plugins.livereload.changed);
@@ -65,7 +66,7 @@ gulp.task('csslint', function (done) {
 
 // JS linting task
 gulp.task('jshint', function () {
-	return gulp.src(_.union(defaultAssets.server.allJS, defaultAssets.client.js, testAssets.tests.server, testAssets.tests.client, testAssets.tests.e2e))
+	return gulp.src(_.union(defaultAssets.server.gulpConfig, defaultAssets.server.allJS, defaultAssets.client.js, testAssets.tests.server, testAssets.tests.client, testAssets.tests.e2e))
 		.pipe(plugins.jshint())
 		.pipe(plugins.jshint.reporter('default'))
 		.pipe(plugins.jshint.reporter('fail'));


### PR DESCRIPTION
### Enhancement: Grunt vs Gulp
If you are running gulp, and edit the gruntconfig.js file, gulp will restart.  This change is to separate automation configuration changes so that gruntfile.js updates do not restart the gulp process.

Additionally, this adds gulpconfig.js monitoring so that it will restart gulp if there are changes to gulpconfig.js

### Bug: Path Separator
There is an issue on windows with path separator when compiling less/sass with gulp.  Grunt does not have this issue.