### PR TITLE
Enable jshint on grunt test tasks

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -230,9 +230,9 @@ module.exports = function (grunt) {
 	grunt.registerTask('build', ['env:dev', 'lint', 'ngAnnotate', 'uglify', 'cssmin']);
 
 	// Run the project tests
-	grunt.registerTask('test', ['env:test', 'copy:localConfig', 'mongoose', 'mochaTest', 'karma:unit']);
-	grunt.registerTask('test:server', ['env:test', 'mongoose', 'mochaTest']);
-	grunt.registerTask('test:client', ['env:test', 'mongoose', 'karma:unit']);
+	grunt.registerTask('test', ['env:test', 'lint', 'copy:localConfig', 'mongoose', 'mochaTest', 'karma:unit']);
+	grunt.registerTask('test:server', ['env:test', 'lint', 'mongoose', 'mochaTest']);
+	grunt.registerTask('test:client', ['env:test', 'lint', 'mongoose', 'karma:unit']);
 
 	// Run the project in development mode
 	grunt.registerTask('default', ['env:dev', 'lint', 'copy:localConfig', 'concurrent:default']);


### PR DESCRIPTION
Enabling the lint task when running tests so we can identify coding convention issues on Pull-Requests in the CI

Addresses issue https://github.com/meanjs/mean/pull/645