### PR TITLE
Remove console.log from an article test

### DIFF
--- a/modules/articles/tests/server/article.server.routes.tests.js
+++ b/modules/articles/tests/server/article.server.routes.tests.js
@@ -226,7 +226,6 @@ describe('Article CRUD tests', function () {
 	it('should return proper error for single article which doesnt exist, if not signed in', function (done) {
 		request(app).get('/api/articles/test')
 			.end(function (req, res) {
-				console.log(res.body);
 				// Set assertion
 				res.body.should.be.instanceof(Object).and.have.property('message', 'Article is invalid');
 


### PR DESCRIPTION
There seems to be an extra console.log laying around in one of the Article Tests. Probably got left behind by someone during debugging. 