### PR TITLE
Support Deploying MEANJS To Cloud Foundry

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,10 @@
+# List of files and directories to ignore when deploying to Cloud Foundry
+.DS_Store
+.nodemonignore
+.sass-cache/
+npm-debug.log
+node_modules/
+public/lib
+app/tests/coverage/
+.bower-*/
+.idea/

--- a/README.md
+++ b/README.md
@@ -165,6 +165,85 @@ In the docs we'll try to explain both general concepts of MEAN components and gi
 ## Live Example
 Browse the live MEAN.JS example on [http://meanjs.herokuapp.com](http://meanjs.herokuapp.com).
 
+## Deploying To Cloud Foundry
+
+Cloud Foundry is an open source platform-as-a-service (PaaS).  The MEANJS project
+can easily be deployed to any Cloud Foundry instance.  The easiest way to deploy the
+MEANJS project to Cloud Foundry is to use a public hosted instance.  The two most popular
+instances are [Pivotal Web Services](https://run.pivotal.io/) and 
+[IBM Bluemix](https://bluemix.net).  Both provide free trials and support pay-as-you-go models
+for hosting applications in the cloud.  After you have an account follow the below steps to 
+deploy MEANJS.
+
+* Install the [Cloud Foundry command line tools](http://docs.cloudfoundry.org/devguide/installcf/install-go-cli.html).
+* Now you need to log into Cloud Foundry from the Cloud Foundry command line.
+  *  If you are using Pivotal Web Services run `$ cf login -a api.run.pivotal.io`.
+  *  If you are using IBM Bluemix run `$ cf login -a api.ng.bluemix.net`.
+* Create a Mongo DB service, IBM Bluemix and Pivotal Web Services offer a free MongoLabs service.
+  *  `$ cf create-service mongolab sandbox mean-mongo`
+* Clone the GitHub repo for MEANJS if you have not already done so
+  * `$ git clone https://github.com/meanjs/mean.git && cd mean`
+* Run the Grunt Build task to build the optimized JavaScript and CSS files
+  * `$ grunt build`
+* Deploy MEANJS to Cloud Foundry
+  * `$ cf push`
+
+After `cf push` completes you will see the URL to your running MEANJS application 
+(your URL will be different).
+
+    requested state: started
+    instances: 1/1
+    usage: 128M x 1 instances
+    urls: mean-humbler-frappa.mybluemix.net
+
+Open your browser and go to that URL and your should see your MEANJS app running!
+
+### Configuring Social Services
+
+The MEANJS application allows you to login via a number of social services.  In other
+deployments of MEANJS you need to configure environment variables with the various
+keys and secrets to enable these social services.  While this is possible in Cloud
+Foundry, it is not the preferred method.  Credentials like this are usually surfaced
+through services an application can bind to.  For this reason, when you deploy
+MEANJS to Cloud Foundry you must configure and bind services to your application
+in order to login with the various social services.  To do this we will use
+what is called 
+[user provided services](http://docs.cloudfoundry.org/devguide/services/user-provided.html).
+
+Once your application is deployed to Cloud Foundry run the following command for the social
+services you would like to use.  Make sure you insert the correct credentials for the service.
+
+#### Facebook
+`$ cf cups mean-facebook -p '{"id":"facebookId","secret":"facebookSecret"}'`
+`$ cf bind-service mean mean-facebook`
+
+#### Twitter
+`$ cf cups mean-twitter -p '{"key":"twitterKey","secret":"twitterSecret"}'`
+`$ cf bind-service mean mean-twitter`
+
+#### Google
+`$ cf cups mean-google -p '{"id":"googleId","secret":"googleSecret"}'`
+`$ cf bind-service mean mean-google`
+
+#### LinkedIn
+`$ cf cups mean-linkedin -p '{"id":"linkedinId","secret":"linkedinSecret"}'`
+`$ cf bind-service mean mean-linkedin`
+
+#### GitHub
+`$ cf cups mean-github -p '{"id":"githubId","secret":"githubSecret"}'`
+`$ cf bind-service mean mean-github`
+
+#### Email
+`$ cf cups mean-mail -p '{"from":"fromEmail","service":"emailService","username":"emailServiceUsername","password":"emailServicePassword"}'`
+`$ cf bind-service mean mean-mail`
+
+#### Paypal
+`$ cf cups mean-paypal -p '{"id":"paypalId","secret":"paypalSecret"}'`
+`$ cf bind-service mean mean-paypal`
+
+After you have bound the services your want to your MEANJS application run
+`$ cf restage mean` to restage your application and your social services should now work.
+
 ## Credits
 Inspired by the great work of [Madhusudhan Srinivasa](https://github.com/madhums/)
 The MEAN name was coined by [Valeri Karpov](http://blog.mongodb.org/post/49262866911/the-mean-stack-mongodb-expressjs-angularjs-and)

--- a/README.md
+++ b/README.md
@@ -204,52 +204,6 @@ After `cf push` completes you will see the URL to your running MEANJS applicatio
 
 Open your browser and go to that URL and your should see your MEANJS app running!
 
-### Configuring Social Services
-
-The MEANJS application allows you to login via a number of social services.  In other
-deployments of MEANJS you need to configure environment variables with the various
-keys and secrets to enable these social services.  While this is possible in Cloud
-Foundry, it is not the preferred method.  Credentials like this are usually surfaced
-through services an application can bind to.  For this reason, when you deploy
-MEANJS to Cloud Foundry you must configure and bind services to your application
-in order to login with the various social services.  To do this we will use
-what is called 
-[user provided services](http://docs.cloudfoundry.org/devguide/services/user-provided.html).
-
-Once your application is deployed to Cloud Foundry run the following command for the social
-services you would like to use.  Make sure you insert the correct credentials for the service.
-
-#### Facebook
-`$ cf cups mean-facebook -p '{"id":"facebookId","secret":"facebookSecret"}'`
-`$ cf bind-service mean mean-facebook`
-
-#### Twitter
-`$ cf cups mean-twitter -p '{"key":"twitterKey","secret":"twitterSecret"}'`
-`$ cf bind-service mean mean-twitter`
-
-#### Google
-`$ cf cups mean-google -p '{"id":"googleId","secret":"googleSecret"}'`
-`$ cf bind-service mean mean-google`
-
-#### LinkedIn
-`$ cf cups mean-linkedin -p '{"id":"linkedinId","secret":"linkedinSecret"}'`
-`$ cf bind-service mean mean-linkedin`
-
-#### GitHub
-`$ cf cups mean-github -p '{"id":"githubId","secret":"githubSecret"}'`
-`$ cf bind-service mean mean-github`
-
-#### Email
-`$ cf cups mean-mail -p '{"from":"fromEmail","service":"emailService","username":"emailServiceUsername","password":"emailServicePassword"}'`
-`$ cf bind-service mean mean-mail`
-
-#### Paypal
-`$ cf cups mean-paypal -p '{"id":"paypalId","secret":"paypalSecret"}'`
-`$ cf bind-service mean mean-paypal`
-
-After you have bound the services your want to your MEANJS application run
-`$ cf restage mean` to restage your application and your social services should now work.
-
 ## Credits
 Inspired by the great work of [Madhusudhan Srinivasa](https://github.com/madhums/)
 The MEAN name was coined by [Valeri Karpov](http://blog.mongodb.org/post/49262866911/the-mean-stack-mongodb-expressjs-angularjs-and)

--- a/config/assets/cloud-foundry.js
+++ b/config/assets/cloud-foundry.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+	client: {
+		lib: {
+			css: [
+				'public/lib/bootstrap/dist/css/bootstrap.min.css',
+				'public/lib/bootstrap/dist/css/bootstrap-theme.min.css',
+			],
+			js: [
+				'public/lib/angular/angular.min.js',
+				'public/lib/angular-resource/angular-resource.min.js',
+				'public/lib/angular-animate/angular-animate.min.js',
+				'public/lib/angular-ui-router/release/angular-ui-router.min.js',
+				'public/lib/angular-ui-utils/ui-utils.min.js',
+				'public/lib/angular-bootstrap/ui-bootstrap-tpls.min.js',
+				'public/lib/angular-file-upload/angular-file-upload.min.js'
+			]
+		},
+		css: 'public/dist/application.min.css',
+		js: 'public/dist/application.min.js'
+	}
+};

--- a/config/env/cloud-foundry.js
+++ b/config/env/cloud-foundry.js
@@ -1,0 +1,71 @@
+'use strict';
+
+var cfenv = require('cfenv'),
+    appEnv = cfenv.getAppEnv(),
+    cfMongoUrl = appEnv.getService('mean-mongo') ? 
+    appEnv.getService('mean-mongo').credentials.uri : undefined;
+
+var getCred = function(serviceName, credProp) {
+	return appEnv.getService(serviceName) ? 
+    appEnv.getService(serviceName).credentials[credProp] : undefined;	
+};
+
+module.exports = {
+	port:  appEnv.port,
+	db: {
+		uri: cfMongoUrl,
+		options: {
+			user: '',
+			pass: ''
+		}
+	},
+	log: {
+		// Can specify one of 'combined', 'common', 'dev', 'short', 'tiny'
+		format: 'combined',
+		// Stream defaults to process.stdout
+		// By default we want logs to go to process.out so the Cloud Foundry Loggregator will collect them
+		options: {
+		}
+	},
+	facebook: {
+		clientID: getCred('mean-facebook', 'id') || 'APP_ID',
+		clientSecret: getCred('mean-facebook', 'secret') || 'APP_SECRET',
+		callbackURL: '/api/auth/facebook/callback'
+	},
+	twitter: {
+		clientID: getCred('mean-twitter', 'key') || 'CONSUMER_KEY',
+		clientSecret: getCred('mean-twitter', 'secret') || 'CONSUMER_SECRET',
+		callbackURL: '/api/auth/twitter/callback'
+	},
+	google: {
+		clientID: getCred('mean-google', 'id') || 'APP_ID',
+		clientSecret: getCred('mean-google', 'secret') || 'APP_SECRET',
+		callbackURL: '/api/auth/google/callback'
+	},
+	linkedin: {
+		clientID: getCred('mean-linkedin', 'id') || 'APP_ID',
+		clientSecret: getCred('mean-linkedin', 'secret') || 'APP_SECRET',
+		callbackURL: '/api/auth/linkedin/callback'
+	},
+	github: {
+		clientID: getCred('mean-github', 'id') || 'APP_ID',
+		clientSecret: getCred('mean-github', 'secret') || 'APP_SECRET',
+		callbackURL: '/api/auth/github/callback'
+	},
+	paypal: {
+		clientID: getCred('mean-paypal', 'id') || 'CLIENT_ID',
+		clientSecret: getCred('mean-paypal', 'secret') || 'CLIENT_SECRET',
+		callbackURL: '/api/auth/paypal/callback',
+		sandbox: false
+	},
+	mailer: {
+		from: getCred('mean-mail', 'from') || 'MAILER_FROM',
+		options: {
+			service: getCred('mean-mail', 'service') || 'MAILER_SERVICE_PROVIDER',
+			auth: {
+				user: getCred('mean-mail', 'username') || 'MAILER_EMAIL_ID',
+				pass: getCred('mean-mail', 'password') || 'MAILER_PASSWORD'
+			}
+		}
+	}
+};

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,8 @@
+applications:
+- name: mean
+  host: mean-${random-word}
+  memory: 128M
+  services:
+  - mean-mongo
+  env:
+    NODE_ENV: production

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,4 +5,4 @@ applications:
   services:
   - mean-mongo
   env:
-    NODE_ENV: production
+    NODE_ENV: cloud-foundry

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "serve-favicon": "^2.3.0",
     "socket.io": "^1.3.5",
     "swig": "^1.4.2",
-    "validator": "^3.41.2"
+    "validator": "^3.41.2",
+    "cfenv": "~1.0.0"
   },
   "devDependencies": {
     "grunt-concurrent": "^2.0.0",


### PR DESCRIPTION
This is a port of #239 to the 0.4.0 branch.

I have tested the functionality against IBM Bluemix.  The only thing I did not successfully get to work is the login via PayPal.  I don't see exact instructions on how to do that yet so maybe my configuration is wrong.  If anyone has any advice on how to set that up correctly so I can test it that would be much appreciated.