### PR TITLE
Switch TravisCI and DavidDM to 0.4.0 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 [![MEAN.JS Logo](http://meanjs.org/img/logo-small.png)](http://meanjs.org/)
 
+[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/meanjs/mean?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Master Branch: 
 [![Build Status](https://travis-ci.org/meanjs/mean.svg?branch=master)](https://travis-ci.org/meanjs/mean)
 [![Dependencies Status](https://david-dm.org/meanjs/mean.svg)](https://david-dm.org/meanjs/mean)
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/meanjs/mean?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Dev Branch:
+[![Build Status](https://travis-ci.org/meanjs/mean.svg?branch=0.4.0)](https://travis-ci.org/meanjs/mean)
+[![Dependencies Status](https://david-dm.org/meanjs/mean/0.4.0.svg)](https://david-dm.org/meanjs/mean/0.4.0)
 
 MEAN.JS is a full-stack JavaScript open-source solution, which provides a solid starting point for [MongoDB](http://www.mongodb.org/), [Node.js](http://www.nodejs.org/), [Express](http://expressjs.com/), and [AngularJS](http://angularjs.org/) based applications. The idea is to solve the common issues with connecting those frameworks, build a robust framework to support daily development needs, and help developers use better practices while working with popular JavaScript components.
 


### PR DESCRIPTION
In the README.md file on the 0.4.0 branch, the Travis-CI and David-DM badges were displaying the status of the Master Branch, not the 04.0 branch. 