### PR TITLE
Filter states for which login is required during state change

### DIFF
--- a/modules/articles/client/config/articles.client.routes.js
+++ b/modules/articles/client/config/articles.client.routes.js
@@ -18,7 +18,7 @@ angular.module('articles').config(['$stateProvider',
 			url: '/create',
 			templateUrl: 'modules/articles/views/create-article.client.view.html',
 			data: {
-				requiresLogin: true
+				forbiddenRoles: ['guest']
 			}
 		}).
 		state('articles.view', {
@@ -29,7 +29,7 @@ angular.module('articles').config(['$stateProvider',
 			url: '/:articleId/edit',
 			templateUrl: 'modules/articles/views/edit-article.client.view.html',
 			data: {
-				requiresLogin: true
+				forbiddenRoles: ['guest']
 			}
 		});
 	}

--- a/modules/articles/client/config/articles.client.routes.js
+++ b/modules/articles/client/config/articles.client.routes.js
@@ -16,7 +16,10 @@ angular.module('articles').config(['$stateProvider',
 		}).
 		state('articles.create', {
 			url: '/create',
-			templateUrl: 'modules/articles/views/create-article.client.view.html'
+			templateUrl: 'modules/articles/views/create-article.client.view.html',
+			data: {
+				requiresLogin: true
+			}
 		}).
 		state('articles.view', {
 			url: '/:articleId',
@@ -24,7 +27,10 @@ angular.module('articles').config(['$stateProvider',
 		}).
 		state('articles.edit', {
 			url: '/:articleId/edit',
-			templateUrl: 'modules/articles/views/edit-article.client.view.html'
+			templateUrl: 'modules/articles/views/edit-article.client.view.html',
+			data: {
+				requiresLogin: true
+			}
 		});
 	}
 ]);

--- a/modules/articles/client/config/articles.client.routes.js
+++ b/modules/articles/client/config/articles.client.routes.js
@@ -18,7 +18,7 @@ angular.module('articles').config(['$stateProvider',
 			url: '/create',
 			templateUrl: 'modules/articles/views/create-article.client.view.html',
 			data: {
-				forbiddenRoles: ['guest']
+				roles: ['user', 'admin']
 			}
 		}).
 		state('articles.view', {
@@ -29,7 +29,7 @@ angular.module('articles').config(['$stateProvider',
 			url: '/:articleId/edit',
 			templateUrl: 'modules/articles/views/edit-article.client.view.html',
 			data: {
-				forbiddenRoles: ['guest']
+				roles: ['user', 'admin']
 			}
 		});
 	}

--- a/modules/core/client/app/init.js
+++ b/modules/core/client/app/init.js
@@ -13,13 +13,16 @@ angular.module(ApplicationConfiguration.applicationModuleName).config(['$locatio
 angular.module(ApplicationConfiguration.applicationModuleName).run(function($rootScope, $state, Authentication) {
     // Check authentication before changing state
     $rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams) {
-        if (toState.data && toState.data.requiresLogin && Authentication.user === '') {
-            event.preventDefault();
-            $state.go('authentication.signin', {}, {
-                notify: false
-            }).then(function() {
-                $rootScope.$broadcast('$stateChangeSuccess', 'authentication.signin', {}, toState, toParams);
-            });
+        if (toState.data && toState.data.forbiddenRoles) {
+            // If access of guest user is forbidden:
+            if (toState.data.forbiddenRoles.indexOf('guest') !== -1 && Authentication.user === '') {
+                event.preventDefault();
+                $state.go('authentication.signin', {}, {
+                    notify: false
+                }).then(function() {
+                    $rootScope.$broadcast('$stateChangeSuccess', 'authentication.signin', {}, toState, toParams);
+                });
+            }
         }
     });
 });

--- a/modules/core/client/app/init.js
+++ b/modules/core/client/app/init.js
@@ -10,6 +10,20 @@ angular.module(ApplicationConfiguration.applicationModuleName).config(['$locatio
 	}
 ]);
 
+angular.module(ApplicationConfiguration.applicationModuleName).run(function($rootScope, $state, Authentication) {
+    // Check authentication before changing state
+    $rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams) {
+        if (toState.data && toState.data.requiresLogin && Authentication.user === '') {
+            event.preventDefault();
+            $state.go('authentication.signin', {}, {
+                notify: false
+            }).then(function() {
+                $rootScope.$broadcast('$stateChangeSuccess', 'authentication.signin', {}, toState, toParams);
+            });
+        }
+    });
+});
+
 //Then define the init function for starting up the application
 angular.element(document).ready(function() {
 	//Fixing facebook bug with redirect

--- a/modules/core/client/app/init.js
+++ b/modules/core/client/app/init.js
@@ -13,9 +13,9 @@ angular.module(ApplicationConfiguration.applicationModuleName).config(['$locatio
 angular.module(ApplicationConfiguration.applicationModuleName).run(function($rootScope, $state, Authentication) {
     // Check authentication before changing state
     $rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams) {
-        if (toState.data && toState.data.forbiddenRoles) {
-            // If access of guest user is forbidden:
-            if (toState.data.forbiddenRoles.indexOf('guest') !== -1 && Authentication.user === '') {
+        if (toState.data && toState.data.roles) {
+            // If access of guest user is not allowed:
+            if (toState.data.roles.indexOf('guest') === -1 && Authentication.user === '') {
                 event.preventDefault();
                 $state.go('authentication.signin', {}, {
                     notify: false

--- a/modules/users/client/config/users.client.routes.js
+++ b/modules/users/client/config/users.client.routes.js
@@ -8,7 +8,10 @@ angular.module('users').config(['$stateProvider',
 			state('settings', {
 				abstract: true,
 				url: '/settings',
-				templateUrl: 'modules/users/views/settings/settings.client.view.html'
+				templateUrl: 'modules/users/views/settings/settings.client.view.html',
+				data: {
+					requiresLogin: true
+				}
 			}).
 			state('settings.profile', {
 				url: '/profile',

--- a/modules/users/client/config/users.client.routes.js
+++ b/modules/users/client/config/users.client.routes.js
@@ -10,7 +10,7 @@ angular.module('users').config(['$stateProvider',
 				url: '/settings',
 				templateUrl: 'modules/users/views/settings/settings.client.view.html',
 				data: {
-					forbiddenRoles: ['guest']
+					roles: ['user', 'admin']
 				}
 			}).
 			state('settings.profile', {

--- a/modules/users/client/config/users.client.routes.js
+++ b/modules/users/client/config/users.client.routes.js
@@ -10,7 +10,7 @@ angular.module('users').config(['$stateProvider',
 				url: '/settings',
 				templateUrl: 'modules/users/views/settings/settings.client.view.html',
 				data: {
-					requiresLogin: true
+					forbiddenRoles: ['guest']
 				}
 			}).
 			state('settings.profile', {

--- a/modules/users/client/controllers/settings/settings.client.controller.js
+++ b/modules/users/client/controllers/settings/settings.client.controller.js
@@ -3,8 +3,5 @@
 angular.module('users').controller('SettingsController', ['$scope', '$location', 'Authentication',
 	function($scope, $location, Authentication) {
 		$scope.user = Authentication.user;
-
-		// If user is not signed in then redirect back home
-		if (!$scope.user) $location.path('/');
 	}
 ]);


### PR DESCRIPTION
A state parameter was added for the routes that require user authentication. Now, everytime a statechange occurs, the destination state is checked and user is redirected to signin page if necessary (without flickering). Note the state parameter is added within `data`, so that nested states can inherent its value.

This would conflict with  #487 . However, I am anticipating the PR, so that I can receive some feedback.