### PR TITLE
If displayName in Github is undefined

### DIFF
--- a/modules/users/server/config/strategies/github.js
+++ b/modules/users/server/config/strategies/github.js
@@ -22,7 +22,7 @@ module.exports = function(config) {
 			providerData.refreshToken = refreshToken;
 
 			// Create the user OAuth profile
-			var displayName = profile.displayName.trim();
+			var displayName = profile.displayName ? profile.displayName.trim() : profile.username.trim();
 			var iSpace = displayName.indexOf(' '); // index of the whitespace following the firstName
 			var firstName =  iSpace !== -1 ? displayName.substring(0, iSpace) : displayName;
 			var lastName = iSpace !== -1 ? displayName.substring(iSpace + 1) : '';


### PR DESCRIPTION
If a user's displayName in github is undefined, default to the username.
Fixes #519 