### PR TITLE
Enhancing SSL error message

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -80,6 +80,8 @@ var validateSecureMode = function(config) {
 
     if (!privateKey || !certificate) {
         chalk.red(console.log('+ Error: Certificate file or key file is missing, falling back to non-SSL mode'));
+        chalk.red(console.log('  To create them, simply run the following from your shell: sh ./scripts/generate-ssl-certs.sh'));
+        console.log();
         config.secure = false;
     }
 };


### PR DESCRIPTION
# Before 
When running grunt prod with `secured` mode enabled for SSL support, and there were missing key/cert files then the server would fall back to HTTP-only and would notify of the missing SSL files.

# After
Enhancing error message with an actual instruction on how to fix the missing ssl problem when running in prod mode and secured enabled

Addresses concern reported in #678 

![image](https://cloud.githubusercontent.com/assets/316371/8869376/699035cc-31eb-11e5-82f1-3ea415f2664b.png)