### PR TITLE
Putting the head in order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,13 @@ local.properties
 data/
 mongod
 
+# Visual Studio
+# =========
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+
 # General
 # =======
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,20 @@ modules/users/client/img/profile/uploads
 config/env/local.js
 *.pem
 
+# General
+# =======
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+*.tmp
+*.bak
+*.swp
+logs/
+build/
+
 # Sublime editor
 # ==============
 .sublime-project
@@ -55,16 +69,3 @@ mongod
 *.njsproj
 *.sln
 
-# General
-# =======
-*.log
-*.csv
-*.dat
-*.out
-*.pid
-*.gz
-*.tmp
-*.bak
-*.swp
-logs/
-build/

--- a/modules/core/server/views/layout.server.view.html
+++ b/modules/core/server/views/layout.server.view.html
@@ -1,24 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-	<title>{{title}}</title>
-
-	<!-- General META -->
 	<meta charset="utf-8">
-	<meta http-equiv="Content-type" content="text/html;charset=UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-	<meta name="fragment" content="!">
-	<base href="/">
-
-	<!-- Responsive META -->
 	<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1">
+	<base href="/">
+	<title>{{title}}</title>
+	<meta name="description" content="{{description}}">
+	<meta name="fragment" content="!">
+
+	<!-- Apple META -->
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-status-bar-style" content="black">
-
-	<!-- Semantic META -->
-	<meta name="keywords" content="{{keywords}}">
-	<meta name="description" content="{{description}}">
 
 	<!-- Facebook META -->
 	<meta property="fb:app_id" content="{{facebookAppId}}">
@@ -38,13 +31,8 @@
 	<!-- Fav Icon -->
 	<link href="/modules/core/img/brand/favicon.ico" rel="shortcut icon" type="image/x-icon">
 
-	<!--Application CSS Files-->
+	<!-- Application CSS Files -->
 	{% for cssFile in cssFiles %}<link rel="stylesheet" href="{{cssFile}}">{% endfor %}
-
-	<!-- HTML5 Shim -->
-	<!--[if lt IE 9]>
-		<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-	<![endif]-->
 </head>
 
 <body class="ng-cloak">
@@ -59,12 +47,12 @@
 	<script type="text/javascript">
 		var user = {{ user | json | safe }};
 	</script>
-	
+
 	<!--Load The Socket.io File-->
 	<script type="text/javascript" src="/socket.io/socket.io.js"></script>
 
 	<!--Application JavaScript Files-->
-	{% for jsFile in jsFiles %}<script type="text/javascript" src="{{jsFile}}"></script>{% endfor %} 
+	{% for jsFile in jsFiles %}<script type="text/javascript" src="{{jsFile}}"></script>{% endfor %}
 
 	{% if process.env.NODE_ENV === 'development' %}
 	<!--Livereload script rendered -->


### PR DESCRIPTION
- Moving a few meta tags+base tag before the title. I've noticed Bootstrap [recommends this](http://getbootstrap.com/getting-started/#template) (wasn't sure why) so I did some quick googling and [IE seems to be the reason](http://blogs.msdn.com/b/ieinternals/archive/2011/07/18/optimal-html-head-ordering-to-avoid-parser-restarts-redownloads-and-improve-performance.aspx) but there were some other speculations, too. Feel free to search more.

- ...in any case, [charset tag should come before the title](http://www.w3.org/wiki/The_HTML_head_element#Stop_right_there.21_Inline_CSS_and_JavaScript_is_not_too_clever.21).

- Removing keyword tag since it [isn't really used anymore](https://chrisedwards.me/seo/keyword-meta-tag-google/).

- Removing duplicate Content-type/Encoding tag

- Adding respond.min.js so that media queries would work with old IEs.

- Using a proper CDN for shim JS. That previous one was over http (problems when using https) and googlecode.com doesn't send proper cache headers; it's not smart to use it as a CDN.