### PR TITLE
Excluded node_modules

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,6 @@ github_username:  meanjs
 
 # Build settings
 markdown: kramdown
+
+excludes: 
+  - node_modules


### PR DESCRIPTION
Exclude the node_modules directory just in case it's left behind from another branch. 