### PR TITLE
Article middleware was calling getErrorMessage with a null argument

### DIFF
--- a/modules/articles/server/controllers/articles.server.controller.js
+++ b/modules/articles/server/controllers/articles.server.controller.js
@@ -100,7 +100,7 @@ exports.articleByID = function(req, res, next, id) {
 		if (err) return next(err);
 		if (!article) {
 			return res.status(404).send({
-				message: errorHandler.getErrorMessage(err)
+				message: 'No article with that identifier has been found'
 			});
 		}
 		req.article = article;

--- a/modules/articles/tests/server/article.server.routes.tests.js
+++ b/modules/articles/tests/server/article.server.routes.tests.js
@@ -223,11 +223,24 @@ describe('Article CRUD tests', function () {
 		});
 	});
 
-	it('should return proper error for single article which doesnt exist, if not signed in', function (done) {
+	it('should return proper error for single article with an invalid Id, if not signed in', function (done) {
+		// test is not a valid mongoose Id
 		request(app).get('/api/articles/test')
 			.end(function (req, res) {
 				// Set assertion
 				res.body.should.be.instanceof(Object).and.have.property('message', 'Article is invalid');
+
+				// Call the assertion callback
+				done();
+			});
+	});
+
+	it('should return proper error for single article which doesnt exist, if not signed in', function (done) {
+		// This is a valid mongoose Id but a non-existent article
+		request(app).get('/api/articles/559e9cd815f80b4c256a8f41')
+			.end(function (req, res) {
+				// Set assertion
+				res.body.should.be.instanceof(Object).and.have.property('message', 'No article with that identifier has been found');
 
 				// Call the assertion callback
 				done();


### PR DESCRIPTION
The article middleware was calling getErrorMessage with a null argument, causing a crash when this method tried to access 'code' on an null parameter.

The bug was not exposed by the original test, since it was mixing two (related) aspects:

* An invalid Id (a badly formed mongodb identifier)
* An non-existent Id (an identifier with no corresponding document in the database)

Modifications:

- Fixed the message property in the article controller (the error message follows the wording of the error message in "users.password.server.controller.js", in case of username not found)
- Added a new test to check modifications and avoid regressions