### PR TITLE
Updated location of asset file for angularFileUpload

### DIFF
--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -14,7 +14,7 @@ module.exports = {
 				'public/lib/angular-ui-router/release/angular-ui-router.js',
 				'public/lib/angular-ui-utils/ui-utils.js',
 				'public/lib/angular-bootstrap/ui-bootstrap-tpls.js',
-				'public/lib/angular-file-upload/angular-file-upload.js'
+				'public/lib/angular-file-upload/dist/angular-file-upload.min.js'
 			],
 			tests: ['public/lib/angular-mocks/angular-mocks.js']
 		},

--- a/config/assets/production.js
+++ b/config/assets/production.js
@@ -14,7 +14,7 @@ module.exports = {
 				'public/lib/angular-ui-router/release/angular-ui-router.min.js',
 				'public/lib/angular-ui-utils/ui-utils.min.js',
 				'public/lib/angular-bootstrap/ui-bootstrap-tpls.min.js',
-				'public/lib/angular-file-upload/angular-file-upload.min.js'
+				'public/lib/angular-file-upload/dist/angular-file-upload.min.js'
 			]
 		},
 		css: 'public/dist/application.min.css',


### PR DESCRIPTION
This addresses #722. I've updated the default & production assets config to use angualr-file-upload's `public/lib/angular-file-upload/dist/angular-file-upload.min.js`

Currently, after installing the Bower dependencies, the patch version of angular-file-upload is breaking the MEAN app.