### PR TITLE
Fix invalid ng-file-upload paths

### DIFF
--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -14,7 +14,7 @@ module.exports = {
 				'public/lib/angular-ui-router/release/angular-ui-router.js',
 				'public/lib/angular-ui-utils/ui-utils.js',
 				'public/lib/angular-bootstrap/ui-bootstrap-tpls.js',
-				'public/lib/angular-file-upload/angular-file-upload.js'
+				'public/lib/angular-file-upload/src/module.js'
 			],
 			tests: ['public/lib/angular-mocks/angular-mocks.js']
 		},

--- a/config/assets/production.js
+++ b/config/assets/production.js
@@ -14,7 +14,7 @@ module.exports = {
 				'public/lib/angular-ui-router/release/angular-ui-router.min.js',
 				'public/lib/angular-ui-utils/ui-utils.min.js',
 				'public/lib/angular-bootstrap/ui-bootstrap-tpls.min.js',
-				'public/lib/angular-file-upload/angular-file-upload.min.js'
+				'public/lib/angular-file-upload/dist/angular-file-upload.min.js'
 			]
 		},
 		css: 'public/dist/application.min.css',


### PR DESCRIPTION
Did a fresh clone and tested 0.4.0 branch; found out there was an invalid path for ng-file-upload module.

~~It's actually very out-dated (1.1.5 and newest is 5.0.9) but I don't have time now to test if that would work.~~