### PR TITLE
Unauthorized route

### DIFF
--- a/modules/core/client/config/core.client.routes.js
+++ b/modules/core/client/config/core.client.routes.js
@@ -16,6 +16,10 @@ angular.module('core').config(['$stateProvider', '$urlRouterProvider',
 			state('not-found', {
 				url: '/not-found',
 				templateUrl: 'modules/core/views/404.client.view.html'
+			}).
+			state('unauthorized', {
+				url: '/unauthorized',
+				templateUrl: 'modules/core/views/401.client.view.html'
 			});
 	}
 ]);

--- a/modules/core/client/controllers/modal.client.controller.js
+++ b/modules/core/client/controllers/modal.client.controller.js
@@ -1,0 +1,30 @@
+'use strict';
+
+angular.module('core').controller('MeanModalController', ['$scope', '$modalInstance', 'modal',
+	function($scope, $modalInstance, modal) {
+
+		$scope.modal = modal;
+
+		if (modal.items !== undefined) {
+			$scope.items = modal.items;
+			$scope.selected = {
+				item: $scope.items[0]
+			};
+		}
+
+		$scope.ok = function () {
+			if ($scope.selected !== undefined) {
+				$modalInstance.close($scope.selected.item);
+			}
+			else {
+				$modalInstance.close();
+			}
+
+		};
+
+		$scope.cancel = function () {
+			$modalInstance.dismiss('cancel');
+		};
+
+	}
+]);

--- a/modules/core/client/views/401.client.view.html
+++ b/modules/core/client/views/401.client.view.html
@@ -1,0 +1,6 @@
+<h1>Unauthorized</h1>
+<div class="alert alert-danger" role="alert">
+	<span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+	<span class="sr-only">Error:</span>
+	You are not authorized to access this resource
+</div>

--- a/modules/core/client/views/modal.client.view.html
+++ b/modules/core/client/views/modal.client.view.html
@@ -1,0 +1,18 @@
+<div class="modal-header">
+    <h3 class="modal-title">{{modal.title}}</h3>
+</div>
+<div class="modal-body">
+    {{modal.body}}
+    <div data-ng-if="modal.items">
+        <ul>
+            <li ng-repeat="item in items">
+                <a ng-click="selected.item = item">{{ item }}</a>
+            </li>
+        </ul>
+        Selected: <b>{{ selected.item }}</b>
+    </div>
+</div>
+<div class="modal-footer">
+    <button class="btn btn-primary" ng-click="ok()">OK</button>
+    <button data-ng-show="modal.cancel" class="btn btn-warning" ng-click="cancel()">Cancel</button>
+</div>


### PR DESCRIPTION
Attempting to fix the unauthorized client side issues. Added HTTP interceptors that broadcast events to the child scopes. Added a modal to display on unauthorized api calls. Added authorized route and view. To view changes:

Login with a non admin and try and get to the admin routes /admin/users. Should redirect to unauthorized

Add an article with one user, then login with another non admin user, view the article, add /edit at the end of the url and try and edit the article. Should produce a modal that says forbidden.

PR also comes with an angular bootstrap modal in core that can be reused