### PR TITLE
Updated angular-file-upload to use static dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "angular-bootstrap": "~0.13",
     "angular-ui-utils": "bower",
     "angular-ui-router": "~0.2",
-    "angular-file-upload": "~1.1.5"
+    "angular-file-upload": "1.1.5"
   },
   "resolutions": {
     "angular": "~1.3"


### PR DESCRIPTION
Setting angular-file-upload version in Bower.json to be static at 1.1.5

Fixes meanjs/mean#722 & PR meanjs/mean#724