### PR TITLE
Remove generator references from readme and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,8 @@ $ npm install -g grunt-cli
 ## Downloading MEAN.JS
 There are several ways you can get the MEAN.JS boilerplate:
 
-### Yo Generator
-The recommended way would be to use the [Official Yo Generator](http://meanjs.org/generator.html), which generates the latest stable copy of the MEAN.JS boilerplate and supplies multiple sub-generators to ease your daily development cycles.
-
 ### Cloning The GitHub Repository
-You can also use Git to directly clone the MEAN.JS repository:
+The recommended way to get MEAN.js is to use git to directly clone the MEAN.JS repository:
 
 ```bash
 $ git clone https://github.com/meanjs/mean.git meanjs
@@ -59,6 +56,9 @@ $ wget https://github.com/meanjs/mean/archive/master.zip -O meanjs.zip; unzip me
 ```
 
 Don't forget to rename **mean-master** after your project name.
+
+### Yo Generator		
+-Another way would be to use the [Official Yo Generator](http://meanjs.org/generator.html), which generates a copy of the MEAN.JS 0.3.x boilerplate and supplies multiple sub-generators to ease your daily development cycles. 
 
 ## Quick Install
 Once you've downloaded the boilerplate and installed all the prerequisites, you're just a few steps away from starting to develop your MEAN application.

--- a/modules/core/client/views/home.client.view.html
+++ b/modules/core/client/views/home.client.view.html
@@ -76,8 +76,8 @@
 			<ul>
 				<li><a target="_blank" href="http://meanjs.org/docs.html">MEAN.JS Documentation</a>
 				</li>
-				<li><a target="_blank" href="http://meanjs.org/generator.html">Yeoman Generator</a>
-				</li>
+				<!-- <li><a target="_blank" href="http://meanjs.org/generator.html">Yeoman Generator</a>
+				</li> -->
 				<li><a target="_blank" href="http://meanjs.org/modules.html">Modules</a>
 				</li>
 				<li><a target="_blank" href="http://meanjs.org/changelog.html">Changelog</a>


### PR DESCRIPTION
Removed generator references from the README and index view. 

@ilanbiala @lirantal - I would suggest this get merged into 0.4.0 prior to the release to prevent confusion. 