### PR TITLE
Add generator notice

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -66,6 +66,9 @@ title: Generator
       Last updated: 03 Aug 2014.
     </i>
 
+    <div class="alert alert-danger" role="alert"><strong>The generator is for the 0.3.x stable release!</strong> 
+      The generator for the latest master/0.4.0 release is under development. See the <a href="https://github.com/meanjs/generator-meanjs/tree/0.4-dev">github repo</a> for more information about the 0.4.0 generator</div>
+
     <div class="inner-link-anchor" id="overview"></div>
     <section class="page-header">
       <h1 class="pull-left">Overview</h1>


### PR DESCRIPTION
@lirantal @ilanbiala 

This is what I was thinking about doing for the notice about the generator. So it's still on the website, and still listed in the 0.3.x version of the docs, it's just removed from the 0.4.0 docs and and 0.4.0 README until we get it ready to use for 0.4.x.