### PR TITLE
Updating .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 .sass-cache/
 npm-debug.log
 node_modules/
-public/lib
+public/
+config/
 server/test/coverage/
 
 _site/


### PR DESCRIPTION
updating gh-pages gitignore to ignore the public/ and config/ directories which exist on master and other dev branches, this is so we can work seamlessly on different branches (gh-pages vs dev branches)