### PR TITLE
scroll to top automatically on each page transition

### DIFF
--- a/modules/core/server/views/index.server.view.html
+++ b/modules/core/server/views/index.server.view.html
@@ -1,5 +1,6 @@
 {% extends 'layout.server.view.html' %}
 
 {% block content %}
-  <section data-ui-view></section>
+  <section data-ui-view autoscroll="true"></section>
 {% endblock %}
+


### PR DESCRIPTION
For most mean applications, scrolling to top on each page transition should look natural.
This change would save time of many developers (like me.)

How do you guys think?