### PR TITLE
Gitignore for Jekyll assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ modules/users/client/img/profile/uploads
 config/env/local.js
 *.pem
 
+# Ignoring MEAN.JS's gh-pages branch for documenation
+_site/
+
 # General
 # =======
 *.log


### PR DESCRIPTION
updating gitignore file to disregard the _site/ directory which gets created when using jekyll for generating the gh-pages documentation branch locally