### PR TITLE
Refactoring Tests for User model

### DIFF
--- a/modules/users/tests/server/user.server.model.tests.js
+++ b/modules/users/tests/server/user.server.model.tests.js
@@ -17,7 +17,7 @@ var user, user2, user3;
  */
 describe('User Model Unit Tests:', function () {
   before(function (done) {
-    user = new User({
+    user = {
       firstName: 'Full',
       lastName: 'Name',
       displayName: 'Full Name',
@@ -25,8 +25,8 @@ describe('User Model Unit Tests:', function () {
       username: 'username',
       password: 'password',
       provider: 'local'
-    });
-    user2 = new User({
+    };
+    user2 = {
       firstName: 'Full',
       lastName: 'Name',
       displayName: 'Full Name',
@@ -34,8 +34,8 @@ describe('User Model Unit Tests:', function () {
       username: 'username',
       password: 'password',
       provider: 'local'
-    });
-    user3 = new User({
+    };
+    user3 = {
       firstName: 'Different',
       lastName: 'User',
       displayName: 'Full Different Name',
@@ -43,7 +43,7 @@ describe('User Model Unit Tests:', function () {
       username: 'different_username',
       password: 'different_password',
       provider: 'local'
-    });
+    };
 
     done();
   });
@@ -57,59 +57,92 @@ describe('User Model Unit Tests:', function () {
     });
 
     it('should be able to save without problems', function (done) {
-      user.save(done);
-    });
-
-    it('should fail to save an existing user again', function (done) {
-      user.save(function () {
-        user2.save(function (err) {
-          should.exist(err);
+      var _user = new User(user);
+      
+      _user.save(function (err) {
+        should.not.exist(err);
+        _user.remove(function (err) {
+          should.not.exist(err);
           done();
         });
       });
     });
 
+    it('should fail to save an existing user again', function (done) {
+      var _user = new User(user);
+      var _user2 = new User(user2);
+
+      _user.save(function () {
+        _user2.save(function (err) {
+          should.exist(err);
+          _user.remove(function (err) {
+            should.not.exist(err);
+            done();
+          });
+        });
+      });
+    });
+
     it('should be able to show an error when try to save without first name', function (done) {
-      user.firstName = '';
-      return user.save(function (err) {
+      var _user = new User(user);
+
+      _user.firstName = '';
+      _user.save(function (err) {
         should.exist(err);
         done();
       });
     });
 
     it('should confirm that saving user model doesnt change the password', function (done) {
-      user.firstName = 'test';
-      var passwordBefore = user.password;
-      return user.save(function (err) {
-        var passwordAfter = user.password;
-        passwordBefore.should.equal(passwordAfter);
-        done();
+      var _user = new User(user);
+
+      _user.save(function (err) {
+        should.not.exist(err);
+        var passwordBefore = _user.password;
+        _user.firstName = 'test';
+        _user.save(function (err) {
+          var passwordAfter = _user.password;
+          passwordBefore.should.equal(passwordAfter);
+          _user.remove(function (err) {
+            should.not.exist(err);
+            done();
+          });
+        });
       });
     });
 
     it('should be able to save 2 different users', function (done) {
-      user.remove(function (err) {
+      var _user = new User(user);
+      var _user3 = new User(user3);
+
+      _user.save(function (err) {
         should.not.exist(err);
-        user.save(function (err) {
-          user3.save(function (err) {
+        _user3.save(function (err) {
+          should.not.exist(err);
+          _user3.remove(function (err) {
             should.not.exist(err);
-            user3.remove(function (err) {
+            _user.remove(function (err) {
               should.not.exist(err);
               done();
             });
-
           });
         });
       });
     });
 
     it('should not be able to save different user with the same email address', function (done) {
-      user.remove(function (err) {
+      var _user = new User(user);
+      var _user3 = new User(user3);
+
+      _user.remove(function (err) {
         should.not.exist(err);
-        user.save(function (err) {
-          user3.email = user.email;
-          user3.save(function (err) {
+        _user.save(function (err) {
+          var user3_email = _user3.email;
+          _user3.email = _user.email;
+          _user3.save(function (err) {
             should.exist(err);
+            // Restoring the original email for test3 so it can be used in later tests
+            _user3.email = user3_email;
             done();
           });
         });


### PR DESCRIPTION
re-factoring the server model tests to create user model from schema only during tests, so that we can re-use mongodb's _v versioning fields, and also cleaning up user tests on each test iteration