### PR TITLE
Grunt - fail the build if a task fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ env:
   - NODE_ENV=travis
 services:
   - mongodb
+before_install:
+  - gem update --system
+  - gem install sass --version "=3.3.7"

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -207,9 +207,6 @@ module.exports = function (grunt) {
   // Load NPM tasks
   require('load-grunt-tasks')(grunt);
 
-  // Making grunt default to force in order not to break the project.
-  grunt.option('force', true);
-
   // Make sure upload directory exists
   grunt.task.registerTask('mkdir:upload', 'Task that makes sure upload directory exists.', function () {
     // Get the callback


### PR DESCRIPTION
Updating grunt 'force' option to default/force it to false so that we can fail any task that is failing and thus fail the build in case of any issues in tests, jshint conventions, and so on.

This ensures that our CI process is catching any issues.