### PR TITLE
[bug fix] Fixed Menus remove methods

### DIFF
--- a/modules/core/client/services/menus.client.service.js
+++ b/modules/core/client/services/menus.client.service.js
@@ -137,13 +137,13 @@ angular.module('core').service('Menus', [
     };
 
     // Remove existing menu object by menu id
-    this.removeMenuItem = function (menuId, menuItemURL) {
+    this.removeMenuItem = function (menuId, state) {
       // Validate that the menu exists
       this.validateMenuExistance(menuId);
 
       // Search for menu item to remove
       for (var itemIndex in this.menus[menuId].items) {
-        if (this.menus[menuId].items[itemIndex].link === menuItemURL) {
+        if (this.menus[menuId].items[itemIndex].state === state) {
           this.menus[menuId].items.splice(itemIndex, 1);
         }
       }
@@ -153,14 +153,14 @@ angular.module('core').service('Menus', [
     };
 
     // Remove existing menu object by menu id
-    this.removeSubMenuItem = function (menuId, submenuItemURL) {
+    this.removeSubMenuItem = function (menuId, state) {
       // Validate that the menu exists
       this.validateMenuExistance(menuId);
 
       // Search for menu item to remove
       for (var itemIndex in this.menus[menuId].items) {
         for (var subitemIndex in this.menus[menuId].items[itemIndex].items) {
-          if (this.menus[menuId].items[itemIndex].items[subitemIndex].link === submenuItemURL) {
+          if (this.menus[menuId].items[itemIndex].items[subitemIndex].state === state) {
             this.menus[menuId].items[itemIndex].items.splice(subitemIndex, 1);
           }
         }


### PR DESCRIPTION
The Menus client service was attempting to remove Menu items & Sub Menu
items by comparing the `link` field. This field no longer exists; we're
using state. I double checked that there were no existing uses of the Menus `link` field. 

This was pointed out by @cdriscol with #777 

One question/concern.. this could potentially be a breaking change, if users merge this fix, and are using the `link` field somewhere in their custom Menu's. Is this a valid concern? I'm still a little shaky on how we're handling the bug fixes with the current release/branching strategy.

@rhutchison @codydaig @ilanbiala @trainerbill @lirantal 