### PR TITLE
Allow Guests to view Articles

### DIFF
--- a/modules/articles/client/config/articles.client.routes.js
+++ b/modules/articles/client/config/articles.client.routes.js
@@ -8,10 +8,7 @@ angular.module('articles').config(['$stateProvider',
       .state('articles', {
         abstract: true,
         url: '/articles',
-        template: '<ui-view/>',
-        data: {
-          roles: ['user', 'admin']
-        }
+        template: '<ui-view/>'
       })
       .state('articles.list', {
         url: '',
@@ -19,7 +16,10 @@ angular.module('articles').config(['$stateProvider',
       })
       .state('articles.create', {
         url: '/create',
-        templateUrl: 'modules/articles/views/create-article.client.view.html'
+        templateUrl: 'modules/articles/views/create-article.client.view.html',
+        data: {
+          roles: ['user', 'admin']
+        }
       })
       .state('articles.view', {
         url: '/:articleId',
@@ -27,7 +27,10 @@ angular.module('articles').config(['$stateProvider',
       })
       .state('articles.edit', {
         url: '/:articleId/edit',
-        templateUrl: 'modules/articles/views/edit-article.client.view.html'
+        templateUrl: 'modules/articles/views/edit-article.client.view.html',
+        data: {
+          roles: ['user', 'admin']
+        }
       });
   }
 ]);


### PR DESCRIPTION
Currently, the API on the server allows anybody (regardless if signed in or not) to retrieve a list of articles. However, the client requires the user to be logged in to view the articles. This makes it so visitors that are not authenticated to view the articles. 

This goes along with #780 that makes the TopBar visible by default. 