### PR TITLE
Added Deploy To Bluemix button to the README

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -1,0 +1,42 @@
+---
+stages:
+- name: Build
+  inputs:
+  - type: git
+    branch: master
+  triggers:
+  - type: commit
+  jobs:
+  - name: meanjs-build
+    type: builder
+    artifact_dir: ./
+    build_type: grunt
+    script: |-
+      #!/bin/bash
+      # Install RVM, Ruby, and SASS
+      # Needed when running grunt build
+      gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+      curl -sSL https://get.rvm.io | bash -s stable --ruby --gems=sass
+      # Start RVM
+      source /home/jenkins/.rvm/scripts/rvm
+      # Build MEANJS
+      npm install
+      grunt build
+- name: Deploy
+  inputs:
+  - type: job
+    stage: Build
+    job: meanjs-build
+  jobs:
+  - name: Deploy
+    type: deployer
+    target:
+      url: ${CF_TARGET_URL}
+      organization: ${CF_ORGANIZATION}
+      space: ${CF_SPACE}
+      application: ${CF_APP}
+    script: |-
+      #!/bin/bash
+      cf push
+      # view logs
+      #cf logs "${CF_APP}" --recent

--- a/README.md
+++ b/README.md
@@ -199,6 +199,17 @@ After `cf push` completes you will see the URL to your running MEANJS applicatio
 
 Open your browser and go to that URL and your should see your MEANJS app running!
 
+###  Deploying MEANJS To IBM Bluemix
+IBM Bluemix is a Cloud Foundry based PaaS.  By clicking the button below you can signup for Bluemix and deploy
+a working copy of MEANJS to the cloud without having to do the steps above.
+
+[![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https%3A%2F%2Fgithub.com%2Fmeanjs%2Fmean)
+
+After the deployment is finished you will be left with a copy of the MEANJS code in your own private Git repo
+in Bluemix complete with a pre-configured build and deploy pipeline.  Just clone the Git repo, make your changes, and
+commit them back.  Once your changes are committed, the build and deploy pipeline will run automatically deploying
+your changes to Bluemix.
+
 ## Credits
 Inspired by the great work of [Madhusudhan Srinivasa](https://github.com/madhums/)
 The MEAN name was coined by [Valeri Karpov](http://blog.mongodb.org/post/49262866911/the-mean-stack-mongodb-expressjs-angularjs-and)


### PR DESCRIPTION
After adding support to deploy MEANJS to Cloud Foundry, this pull request adds support for the "Deploy To Bluemix" button.  With a single click this button will deploy a working copy of MEANJS to Bluemix.  In addition to the running instance of MEANJS in the cloud, it also creates a copy of the code in a Git repo in Bluemix and sets up a build and deploy pipeline to the repo.  This allows the user to deploy changes made to MEANJS to Bluemix just by doing a `git commit`.

To see this functionality in action you can checkout the [README in my fork](https://github.com/ryanjbaxter/mean).  Just click the Deploy To Bluemix button to test it out.