### PR TITLE
used __dirname instead of process.cwd(), this leads to server errors ...

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -98,7 +98,7 @@ var initGlobalConfigFolders = function (config, assets) {
   };
 
   // Setting globbed client paths
-  config.folders.client = getGlobbedPaths(path.join(__dirname, 'modules/*/client/'), __dirname.replace(new RegExp(/\\/g), '/'));
+  config.folders.client = getGlobbedPaths(path.join(__dirname, '../modules/*/client/'), path.resolve(__dirname + '/..'));
 };
 
 /**

--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -63,7 +63,7 @@ module.exports.initMiddleware = function (app) {
   }));
 
   // Initialize favicon middleware
-  app.use(favicon('./modules/core/client/img/brand/favicon.ico'));
+  app.use(favicon(__dirname + '../../../modules/core/client/img/brand/favicon.ico'));
 
   // Environment dependent middleware
   if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
…if the executable is not run in the same directory.

Simple thing, tested the new meanjs on our farm and instantly ran into this.

The usual way to reproduce this is to start a node instance not by beeing in the folder itself. Everybody can reproduce this behaviour on his own machine, but in my purpose this is to run it on the server.

1. clone mean
2. run ´npm install´
3. cd into any other directory (server-specific would be like 1 directories up like `/root/app/`)
4. `node app/server.js` or as I did: forever start `/root/app/server.js`
--> process.cwd() is going for the directory in which the process was started.