### PR TITLE
Express sessionKey configuration option

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -9,7 +9,12 @@ module.exports = {
   },
   port: process.env.PORT || 3000,
   templateEngine: 'swig',
+  // Session details
+  // sessionSecret should be changed for security measures and concerns
   sessionSecret: 'MEAN',
+  // sessionKey is set to the generic sessionId key used by PHP applications
+  // for obsecurity reasons
+  sessionKey: 'sessionId',
   sessionCollection: 'sessions',
   logo: 'modules/core/img/brand/logo.png',
   favicon: 'modules/core/img/brand/favicon.ico'

--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -115,6 +115,7 @@ module.exports.initSession = function (app, db) {
     saveUninitialized: true,
     resave: true,
     secret: config.sessionSecret,
+    key: config.sessionKey,
     store: new MongoStore({
       mongooseConnection: db.connection,
       collection: config.sessionCollection


### PR DESCRIPTION
Adding support for sessionKey configuration parameter to allow to easily change the session key that is used to hold the session value. The default is a generic sessionId key to introduce security through obscurity.