### PR TITLE
Articles admin feature

### DIFF
--- a/modules/articles/client/articles.client.module.js
+++ b/modules/articles/client/articles.client.module.js
@@ -2,6 +2,8 @@
   'use strict';
 
   app.registerModule('articles', ['core']);// The core module is required for special route handling; see /core/client/config/core.client.routes
+  app.registerModule('articles.admin', ['core.admin']);
+  app.registerModule('articles.admin.routes', ['core.admin.routes']);
   app.registerModule('articles.services');
   app.registerModule('articles.routes', ['ui.router', 'core.routes', 'articles.services']);
 }(ApplicationConfiguration));

--- a/modules/articles/client/config/articles-admin.client.config.js
+++ b/modules/articles/client/config/articles-admin.client.config.js
@@ -1,0 +1,17 @@
+﻿(function () {
+  'use strict';
+
+  // Configuring the Articles Admin module
+  angular
+    .module('articles.admin')
+    .run(menuConfig);
+
+  menuConfig.$inject = ['menuService'];
+
+  function menuConfig(Menus) {
+    Menus.addSubMenuItem('topbar', 'admin', {
+      title: 'Manage Articles',
+      state: 'admin.articles.list'
+    });
+  }
+}());

--- a/modules/articles/client/config/articles-admin.client.routes.js
+++ b/modules/articles/client/config/articles-admin.client.routes.js
@@ -1,0 +1,65 @@
+﻿(function () {
+  'use strict';
+
+  angular
+    .module('articles.admin.routes')
+    .config(routeConfig);
+
+  routeConfig.$inject = ['$stateProvider'];
+
+  function routeConfig($stateProvider) {
+    $stateProvider
+      .state('admin.articles', {
+        abstract: true,
+        url: '/articles',
+        template: '<ui-view/>'
+      })
+      .state('admin.articles.list', {
+        url: '',
+        templateUrl: 'modules/articles/client/views/admin/list-articles.client.view.html',
+        controller: 'ArticlesListController',
+        controllerAs: 'vm',
+        data: {
+          roles: ['admin']
+        }
+      })
+      .state('admin.articles.create', {
+        url: '/create',
+        templateUrl: 'modules/articles/client/views/admin/form-article.client.view.html',
+        controller: 'ArticlesController',
+        controllerAs: 'vm',
+        data: {
+          roles: ['admin']
+        },
+        resolve: {
+          articleResolve: newArticle
+        }
+      })
+      .state('admin.articles.edit', {
+        url: '/:articleId/edit',
+        templateUrl: 'modules/articles/client/views/admin/form-article.client.view.html',
+        controller: 'ArticlesController',
+        controllerAs: 'vm',
+        data: {
+          roles: ['admin']
+        },
+        resolve: {
+          articleResolve: getArticle
+        }
+      });
+  }
+
+  getArticle.$inject = ['$stateParams', 'ArticlesService'];
+
+  function getArticle($stateParams, ArticlesService) {
+    return ArticlesService.get({
+      articleId: $stateParams.articleId
+    }).$promise;
+  }
+
+  newArticle.$inject = ['ArticlesService'];
+
+  function newArticle(ArticlesService) {
+    return new ArticlesService();
+  }
+}());

--- a/modules/articles/client/config/articles.client.menus.js
+++ b/modules/articles/client/config/articles.client.menus.js
@@ -18,14 +18,8 @@
     // Add the dropdown list item
     menuService.addSubMenuItem('topbar', 'articles', {
       title: 'List Articles',
-      state: 'articles.list'
-    });
-
-    // Add the dropdown create item
-    menuService.addSubMenuItem('topbar', 'articles', {
-      title: 'Create Article',
-      state: 'articles.create',
-      roles: ['user']
+      state: 'articles.list',
+      roles: ['*']
     });
   }
 }());

--- a/modules/articles/client/config/articles.client.routes.js
+++ b/modules/articles/client/config/articles.client.routes.js
@@ -23,32 +23,6 @@
           pageTitle: 'Articles List'
         }
       })
-      .state('articles.create', {
-        url: '/create',
-        templateUrl: 'modules/articles/client/views/form-article.client.view.html',
-        controller: 'ArticlesController',
-        controllerAs: 'vm',
-        resolve: {
-          articleResolve: newArticle
-        },
-        data: {
-          roles: ['user', 'admin'],
-          pageTitle: 'Articles Create'
-        }
-      })
-      .state('articles.edit', {
-        url: '/:articleId/edit',
-        templateUrl: 'modules/articles/client/views/form-article.client.view.html',
-        controller: 'ArticlesController',
-        controllerAs: 'vm',
-        resolve: {
-          articleResolve: getArticle
-        },
-        data: {
-          roles: ['user', 'admin'],
-          pageTitle: 'Edit Article {{ articleResolve.title }}'
-        }
-      })
       .state('articles.view', {
         url: '/:articleId',
         templateUrl: 'modules/articles/client/views/view-article.client.view.html',
@@ -69,11 +43,5 @@
     return ArticlesService.get({
       articleId: $stateParams.articleId
     }).$promise;
-  }
-
-  newArticle.$inject = ['ArticlesService'];
-
-  function newArticle(ArticlesService) {
-    return new ArticlesService();
   }
 }());

--- a/modules/articles/client/controllers/admin/article.client.controller.js
+++ b/modules/articles/client/controllers/admin/article.client.controller.js
@@ -1,0 +1,48 @@
+﻿(function () {
+  'use strict';
+
+  angular
+    .module('articles.admin')
+    .controller('ArticlesController', ArticlesController);
+
+  ArticlesController.$inject = ['$scope', '$state', '$window', 'articleResolve', 'Authentication'];
+
+  function ArticlesController($scope, $state, $window, article, Authentication) {
+    var vm = this;
+
+    vm.article = article;
+    vm.authentication = Authentication;
+    vm.error = null;
+    vm.form = {};
+    vm.remove = remove;
+    vm.save = save;
+
+    // Remove existing Article
+    function remove() {
+      if ($window.confirm('Are you sure you want to delete?')) {
+        vm.article.$remove($state.go('admin.articles.list'));
+      }
+    }
+
+    // Save Article
+    function save(isValid) {
+      if (!isValid) {
+        $scope.$broadcast('show-errors-check-validity', 'vm.form.articleForm');
+        return false;
+      }
+
+      // Create a new article, or update the current instance
+      vm.article.createOrUpdate()
+        .then(successCallback)
+        .catch(errorCallback);
+
+      function successCallback(res) {
+        $state.go('admin.articles.list'); // should we send the User to the list or the updated Article's view?
+      }
+
+      function errorCallback(res) {
+        vm.error = res.data.message;
+      }
+    }
+  }
+}());

--- a/modules/articles/client/controllers/admin/list-articles.client.controller.js
+++ b/modules/articles/client/controllers/admin/list-articles.client.controller.js
@@ -1,0 +1,15 @@
+﻿(function () {
+  'use strict';
+
+  angular
+    .module('articles')
+    .controller('ArticlesListController', ArticlesListController);
+
+  ArticlesListController.$inject = ['ArticlesService'];
+
+  function ArticlesListController(ArticlesService) {
+    var vm = this;
+
+    vm.articles = ArticlesService.query();
+  }
+}());

--- a/modules/articles/client/controllers/articles.client.controller.js
+++ b/modules/articles/client/controllers/articles.client.controller.js
@@ -5,46 +5,14 @@
     .module('articles')
     .controller('ArticlesController', ArticlesController);
 
-  ArticlesController.$inject = ['$scope', '$state', 'articleResolve', '$window', 'Authentication'];
+  ArticlesController.$inject = ['$scope', 'articleResolve', 'Authentication'];
 
-  function ArticlesController($scope, $state, article, $window, Authentication) {
+  function ArticlesController($scope, article, Authentication) {
     var vm = this;
 
     vm.article = article;
     vm.authentication = Authentication;
     vm.error = null;
-    vm.form = {};
-    vm.remove = remove;
-    vm.save = save;
 
-    // Remove existing Article
-    function remove() {
-      if ($window.confirm('Are you sure you want to delete?')) {
-        vm.article.$remove($state.go('articles.list'));
-      }
-    }
-
-    // Save Article
-    function save(isValid) {
-      if (!isValid) {
-        $scope.$broadcast('show-errors-check-validity', 'vm.form.articleForm');
-        return false;
-      }
-
-      // Create a new article, or update the current instance
-      vm.article.createOrUpdate()
-        .then(successCallback)
-        .catch(errorCallback);
-
-      function successCallback(res) {
-        $state.go('articles.view', {
-          articleId: res._id
-        });
-      }
-
-      function errorCallback(res) {
-        vm.error = res.data.message;
-      }
-    }
   }
 }());

--- a/modules/articles/client/views/admin/form-article.client.view.html
+++ b/modules/articles/client/views/admin/form-article.client.view.html
@@ -2,6 +2,11 @@
   <div class="page-header">
     <h1>{{vm.article._id ? 'Edit Article' : 'New Article'}}</h1>
   </div>
+  <div class="pull-right">
+    <a class="btn btn-primary" ng-click="vm.remove()">
+      <i class="glyphicon glyphicon-trash"></i>
+    </a>
+  </div>
   <div class="col-md-12">
     <form name="vm.form.articleForm" class="form-horizontal" ng-submit="vm.save(vm.form.articleForm.$valid)" novalidate>
       <fieldset>

--- a/modules/articles/client/views/admin/list-articles.client.view.html
+++ b/modules/articles/client/views/admin/list-articles.client.view.html
@@ -1,0 +1,26 @@
+﻿<section>
+  <div class="page-header">
+    <h1>
+      Articles
+      <a class="btn btn-primary pull-right" data-ui-sref="admin.articles.create">
+        <i class="glyphicon glyphicon-plus"></i>
+      </a>
+    </h1>
+  </div>
+  <div class="list-group">
+    <a data-ng-repeat="article in vm.articles" data-ui-sref="admin.articles.edit({articleId: article._id})" class="list-group-item">
+      <small class="list-group-item-text">
+        Posted on
+        <span data-ng-bind="article.created | date:'mediumDate'"></span>
+        by
+        <span ng-if="article.user" ng-bind="article.user.displayName"></span>
+        <span ng-if="!article.user">Deleted User</span>
+      </small>
+      <h4 class="list-group-item-heading" data-ng-bind="article.title"></h4>
+      <p class="list-group-item-text" data-ng-bind="article.content"></p>
+    </a>
+  </div>
+  <div class="alert alert-warning text-center" data-ng-if="articles.$resolved && !articles.length">
+    No articles yet, why don't you <a data-ui-sref="admin.articles.create">create one</a>?
+  </div>
+</section>

--- a/modules/articles/client/views/list-articles.client.view.html
+++ b/modules/articles/client/views/list-articles.client.view.html
@@ -15,7 +15,4 @@
       <p class="list-group-item-text" ng-bind="article.content"></p>
     </a>
   </div>
-  <div class="alert alert-warning text-center" ng-if="vm.articles.$resolved && !vm.articles.length">
-    No articles yet, why don't you <a ui-sref="articles.create">create one</a>?
-  </div>
 </section>

--- a/modules/articles/client/views/view-article.client.view.html
+++ b/modules/articles/client/views/view-article.client.view.html
@@ -2,14 +2,6 @@
   <div class="page-header">
     <h1 ng-bind="vm.article.title"></h1>
   </div>
-  <div class="pull-right" ng-show="vm.article.isCurrentUserOwner">
-    <a class="btn btn-primary" ui-sref="articles.edit({ articleId: vm.article._id })">
-      <i class="glyphicon glyphicon-edit"></i>
-    </a>
-    <a class="btn btn-primary" ng-click="vm.remove()">
-      <i class="glyphicon glyphicon-trash"></i>
-    </a>
-  </div>
   <small>
     <em class="text-muted">
       Posted on

--- a/modules/articles/server/policies/articles.server.policy.js
+++ b/modules/articles/server/policies/articles.server.policy.js
@@ -25,7 +25,7 @@ exports.invokeRolesPolicies = function () {
     roles: ['user'],
     allows: [{
       resources: '/api/articles',
-      permissions: ['get', 'post']
+      permissions: ['get']
     }, {
       resources: '/api/articles/:articleId',
       permissions: ['get']

--- a/modules/articles/tests/client/admin.articles.client.controller.tests.js
+++ b/modules/articles/tests/client/admin.articles.client.controller.tests.js
@@ -1,0 +1,168 @@
+﻿(function () {
+  'use strict';
+
+  describe('Articles Controller Tests', function () {
+    // Initialize global variables
+    var ArticlesController,
+      $scope,
+      $httpBackend,
+      $state,
+      Authentication,
+      ArticlesService,
+      mockArticle;
+
+    // The $resource service augments the response object with methods for updating and deleting the resource.
+    // If we were to use the standard toEqual matcher, our tests would fail because the test values would not match
+    // the responses exactly. To solve the problem, we define a new toEqualData Jasmine matcher.
+    // When the toEqualData matcher compares two objects, it takes only object properties into
+    // account and ignores methods.
+    beforeEach(function () {
+      jasmine.addMatchers({
+        toEqualData: function (util, customEqualityTesters) {
+          return {
+            compare: function (actual, expected) {
+              return {
+                pass: angular.equals(actual, expected)
+              };
+            }
+          };
+        }
+      });
+    });
+
+    // Then we can start by loading the main application module
+    beforeEach(module(ApplicationConfiguration.applicationModuleName));
+
+    // The injector ignores leading and trailing underscores here (i.e. _$httpBackend_).
+    // This allows us to inject a service but then attach it to a variable
+    // with the same name as the service.
+    beforeEach(inject(function ($controller, $rootScope, _$state_, _$httpBackend_, _Authentication_, _ArticlesService_) {
+      // Set a new global scope
+      $scope = $rootScope.$new();
+
+      // Point global variables to injected services
+      $httpBackend = _$httpBackend_;
+      $state = _$state_;
+      Authentication = _Authentication_;
+      ArticlesService = _ArticlesService_;
+
+      // create mock article
+      mockArticle = new ArticlesService({
+        _id: '525a8422f6d0f87f0e407a33',
+        title: 'An Article about MEAN',
+        content: 'MEAN rocks!'
+      });
+
+      // Mock logged in user
+      Authentication.user = {
+        roles: ['user']
+      };
+
+      // Initialize the Articles controller.
+      ArticlesController = $controller('ArticlesController as vm', {
+        $scope: $scope,
+        articleResolve: {}
+      });
+
+      // Spy on state go
+      spyOn($state, 'go');
+    }));
+
+    describe('vm.save() as create', function () {
+      var sampleArticlePostData;
+
+      beforeEach(function () {
+        // Create a sample article object
+        sampleArticlePostData = new ArticlesService({
+          title: 'An Article about MEAN',
+          content: 'MEAN rocks!'
+        });
+
+        $scope.vm.article = sampleArticlePostData;
+      });
+
+      it('should send a POST request with the form input values and then locate to new object URL', inject(function (ArticlesService) {
+        // Set POST response
+        $httpBackend.expectPOST('api/articles', sampleArticlePostData).respond(mockArticle);
+
+        // Run controller functionality
+        $scope.vm.save(true);
+        $httpBackend.flush();
+
+        // Test URL redirection after the article was created
+        expect($state.go).toHaveBeenCalledWith('admin.articles.list');
+      }));
+
+      it('should set $scope.vm.error if error', function () {
+        var errorMessage = 'this is an error message';
+        $httpBackend.expectPOST('api/articles', sampleArticlePostData).respond(400, {
+          message: errorMessage
+        });
+
+        $scope.vm.save(true);
+        $httpBackend.flush();
+
+        expect($scope.vm.error).toBe(errorMessage);
+      });
+    });
+
+    describe('vm.save() as update', function () {
+      beforeEach(function () {
+        // Mock article in $scope
+        $scope.vm.article = mockArticle;
+      });
+
+      it('should update a valid article', inject(function (ArticlesService) {
+        // Set PUT response
+        $httpBackend.expectPUT(/api\/articles\/([0-9a-fA-F]{24})$/).respond();
+
+        // Run controller functionality
+        $scope.vm.save(true);
+        $httpBackend.flush();
+
+        // Test URL location to new object
+        expect($state.go).toHaveBeenCalledWith('admin.articles.list');
+      }));
+
+      it('should set $scope.vm.error if error', inject(function (ArticlesService) {
+        var errorMessage = 'error';
+        $httpBackend.expectPUT(/api\/articles\/([0-9a-fA-F]{24})$/).respond(400, {
+          message: errorMessage
+        });
+
+        $scope.vm.save(true);
+        $httpBackend.flush();
+
+        expect($scope.vm.error).toBe(errorMessage);
+      }));
+    });
+
+    describe('vm.remove()', function () {
+      beforeEach(function () {
+        // Setup articles
+        $scope.vm.article = mockArticle;
+      });
+
+      it('should delete the article and redirect to articles', function () {
+        // Return true on confirm message
+        spyOn(window, 'confirm').and.returnValue(true);
+
+        $httpBackend.expectDELETE(/api\/articles\/([0-9a-fA-F]{24})$/).respond(204);
+
+        $scope.vm.remove();
+        $httpBackend.flush();
+
+        expect($state.go).toHaveBeenCalledWith('admin.articles.list');
+      });
+
+      it('should should not delete the article and not redirect', function () {
+        // Return false on confirm message
+        spyOn(window, 'confirm').and.returnValue(false);
+
+        $scope.vm.remove();
+
+        expect($state.go).not.toHaveBeenCalled();
+      });
+    });
+  });
+}());

--- a/modules/articles/tests/client/admin.articles.client.routes.tests.js
+++ b/modules/articles/tests/client/admin.articles.client.routes.tests.js
@@ -1,0 +1,163 @@
+﻿(function () {
+  'use strict';
+
+  describe('Articles Route Tests', function () {
+    // Initialize global variables
+    var $scope,
+      ArticlesService;
+
+    // We can start by loading the main application module
+    beforeEach(module(ApplicationConfiguration.applicationModuleName));
+
+    // The injector ignores leading and trailing underscores here (i.e. _$httpBackend_).
+    // This allows us to inject a service but then attach it to a variable
+    // with the same name as the service.
+    beforeEach(inject(function ($rootScope, _ArticlesService_) {
+      // Set a new global scope
+      $scope = $rootScope.$new();
+      ArticlesService = _ArticlesService_;
+    }));
+
+    describe('Route Config', function () {
+      describe('Main Route', function () {
+        var mainstate;
+        beforeEach(inject(function ($state) {
+          mainstate = $state.get('admin.articles');
+        }));
+
+        it('Should have the correct URL', function () {
+          expect(mainstate.url).toEqual('/articles');
+        });
+
+        it('Should be abstract', function () {
+          expect(mainstate.abstract).toBe(true);
+        });
+
+        it('Should have template', function () {
+          expect(mainstate.template).toBe('<ui-view/>');
+        });
+      });
+
+      describe('List Route', function () {
+        var liststate;
+        beforeEach(inject(function ($state) {
+          liststate = $state.get('admin.articles.list');
+        }));
+
+        it('Should have the correct URL', function () {
+          expect(liststate.url).toEqual('');
+        });
+
+        it('Should be not abstract', function () {
+          expect(liststate.abstract).toBe(undefined);
+        });
+
+        it('Should have templateUrl', function () {
+          expect(liststate.templateUrl).toBe('modules/articles/client/views/admin/list-articles.client.view.html');
+        });
+      });
+
+      describe('Create Route', function () {
+        var createstate,
+          ArticlesController,
+          mockArticle;
+
+        beforeEach(inject(function ($controller, $state, $templateCache) {
+          createstate = $state.get('admin.articles.create');
+          $templateCache.put('modules/articles/client/views/admin/form-article.client.view.html', '');
+
+          // Create mock article
+          mockArticle = new ArticlesService();
+
+          // Initialize Controller
+          ArticlesController = $controller('ArticlesController as vm', {
+            $scope: $scope,
+            articleResolve: mockArticle
+          });
+        }));
+
+        it('Should have the correct URL', function () {
+          expect(createstate.url).toEqual('/create');
+        });
+
+        it('Should have a resolve function', function () {
+          expect(typeof createstate.resolve).toEqual('object');
+          expect(typeof createstate.resolve.articleResolve).toEqual('function');
+        });
+
+        it('should respond to URL', inject(function ($state) {
+          expect($state.href(createstate)).toEqual('/admin/articles/create');
+        }));
+
+        it('should attach an article to the controller scope', function () {
+          expect($scope.vm.article._id).toBe(mockArticle._id);
+          expect($scope.vm.article._id).toBe(undefined);
+        });
+
+        it('Should not be abstract', function () {
+          expect(createstate.abstract).toBe(undefined);
+        });
+
+        it('Should have templateUrl', function () {
+          expect(createstate.templateUrl).toBe('modules/articles/client/views/admin/form-article.client.view.html');
+        });
+      });
+
+      describe('Edit Route', function () {
+        var editstate,
+          ArticlesController,
+          mockArticle;
+
+        beforeEach(inject(function ($controller, $state, $templateCache) {
+          editstate = $state.get('admin.articles.edit');
+          $templateCache.put('modules/articles/client/views/admin/form-article.client.view.html', '');
+
+          // Create mock article
+          mockArticle = new ArticlesService({
+            _id: '525a8422f6d0f87f0e407a33',
+            title: 'An Article about MEAN',
+            content: 'MEAN rocks!'
+          });
+
+          // Initialize Controller
+          ArticlesController = $controller('ArticlesController as vm', {
+            $scope: $scope,
+            articleResolve: mockArticle
+          });
+        }));
+
+        it('Should have the correct URL', function () {
+          expect(editstate.url).toEqual('/:articleId/edit');
+        });
+
+        it('Should have a resolve function', function () {
+          expect(typeof editstate.resolve).toEqual('object');
+          expect(typeof editstate.resolve.articleResolve).toEqual('function');
+        });
+
+        it('should respond to URL', inject(function ($state) {
+          expect($state.href(editstate, {
+            articleId: 1
+          })).toEqual('/admin/articles/1/edit');
+        }));
+
+        it('should attach an article to the controller scope', function () {
+          expect($scope.vm.article._id).toBe(mockArticle._id);
+        });
+
+        it('Should not be abstract', function () {
+          expect(editstate.abstract).toBe(undefined);
+        });
+
+        it('Should have templateUrl', function () {
+          expect(editstate.templateUrl).toBe('modules/articles/client/views/admin/form-article.client.view.html');
+        });
+
+        xit('Should go to unauthorized route', function () {
+
+        });
+      });
+
+    });
+  });
+}());

--- a/modules/articles/tests/client/admin.list.articles.client.controller.tests.js
+++ b/modules/articles/tests/client/admin.list.articles.client.controller.tests.js
@@ -1,9 +1,9 @@
-(function () {
+﻿(function () {
   'use strict';
 
-  describe('Articles Controller Tests', function () {
+  describe('Admin Articles List Controller Tests', function () {
     // Initialize global variables
-    var ArticlesController,
+    var ArticlesListController,
       $scope,
       $httpBackend,
       $state,
@@ -55,17 +55,38 @@
 
       // Mock logged in user
       Authentication.user = {
-        roles: ['user']
+        roles: ['user', 'admin']
       };
 
-      // Initialize the Articles controller.
-      ArticlesController = $controller('ArticlesController as vm', {
-        $scope: $scope,
-        articleResolve: {}
+      // Initialize the Articles List controller.
+      ArticlesListController = $controller('ArticlesListController as vm', {
+        $scope: $scope
       });
 
       // Spy on state go
       spyOn($state, 'go');
     }));
+
+    describe('Instantiate', function () {
+      var mockArticleList;
+
+      beforeEach(function () {
+        mockArticleList = [mockArticle, mockArticle];
+      });
+
+      it('should send a GET request and return all articles', inject(function (ArticlesService) {
+        // Set POST response
+        $httpBackend.expectGET('api/articles').respond(mockArticleList);
+
+
+        $httpBackend.flush();
+
+        // Test form inputs are reset
+        expect($scope.vm.articles.length).toEqual(2);
+        expect($scope.vm.articles[0]).toEqual(mockArticle);
+        expect($scope.vm.articles[1]).toEqual(mockArticle);
+
+      }));
+    });
   });
 }());

--- a/modules/articles/tests/client/articles.client.routes.tests.js
+++ b/modules/articles/tests/client/articles.client.routes.tests.js
@@ -52,7 +52,7 @@
           expect(liststate.abstract).toBe(undefined);
         });
 
-        it('Should have template', function () {
+        it('Should have templateUrl', function () {
           expect(liststate.templateUrl).toBe('modules/articles/client/views/list-articles.client.view.html');
         });
       });
@@ -108,107 +108,6 @@
         });
       });
 
-      describe('Create Route', function () {
-        var createstate,
-          ArticlesController,
-          mockArticle;
-
-        beforeEach(inject(function ($controller, $state, $templateCache) {
-          createstate = $state.get('articles.create');
-          $templateCache.put('modules/articles/client/views/form-article.client.view.html', '');
-
-          // create mock article
-          mockArticle = new ArticlesService();
-
-          // Initialize Controller
-          ArticlesController = $controller('ArticlesController as vm', {
-            $scope: $scope,
-            articleResolve: mockArticle
-          });
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(createstate.url).toEqual('/create');
-        });
-
-        it('Should have a resolve function', function () {
-          expect(typeof createstate.resolve).toEqual('object');
-          expect(typeof createstate.resolve.articleResolve).toEqual('function');
-        });
-
-        it('should respond to URL', inject(function ($state) {
-          expect($state.href(createstate)).toEqual('/articles/create');
-        }));
-
-        it('should attach an article to the controller scope', function () {
-          expect($scope.vm.article._id).toBe(mockArticle._id);
-          expect($scope.vm.article._id).toBe(undefined);
-        });
-
-        it('Should not be abstract', function () {
-          expect(createstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(createstate.templateUrl).toBe('modules/articles/client/views/form-article.client.view.html');
-        });
-      });
-
-      describe('Edit Route', function () {
-        var editstate,
-          ArticlesController,
-          mockArticle;
-
-        beforeEach(inject(function ($controller, $state, $templateCache) {
-          editstate = $state.get('articles.edit');
-          $templateCache.put('modules/articles/client/views/form-article.client.view.html', '');
-
-          // create mock article
-          mockArticle = new ArticlesService({
-            _id: '525a8422f6d0f87f0e407a33',
-            title: 'An Article about MEAN',
-            content: 'MEAN rocks!'
-          });
-
-          // Initialize Controller
-          ArticlesController = $controller('ArticlesController as vm', {
-            $scope: $scope,
-            articleResolve: mockArticle
-          });
-        }));
-
-        it('Should have the correct URL', function () {
-          expect(editstate.url).toEqual('/:articleId/edit');
-        });
-
-        it('Should have a resolve function', function () {
-          expect(typeof editstate.resolve).toEqual('object');
-          expect(typeof editstate.resolve.articleResolve).toEqual('function');
-        });
-
-        it('should respond to URL', inject(function ($state) {
-          expect($state.href(editstate, {
-            articleId: 1
-          })).toEqual('/articles/1/edit');
-        }));
-
-        it('should attach an article to the controller scope', function () {
-          expect($scope.vm.article._id).toBe(mockArticle._id);
-        });
-
-        it('Should not be abstract', function () {
-          expect(editstate.abstract).toBe(undefined);
-        });
-
-        it('Should have templateUrl', function () {
-          expect(editstate.templateUrl).toBe('modules/articles/client/views/form-article.client.view.html');
-        });
-
-        xit('Should go to unauthorized route', function () {
-
-        });
-      });
-
       describe('Handle Trailing Slash', function () {
         beforeEach(inject(function ($state, $rootScope) {
           $state.go('articles.list');
@@ -223,7 +122,6 @@
           expect($state.current.templateUrl).toBe('modules/articles/client/views/list-articles.client.view.html');
         }));
       });
-
     });
   });
 }());

--- a/modules/articles/tests/server/admin.article.server.routes.tests.js
+++ b/modules/articles/tests/server/admin.article.server.routes.tests.js
@@ -1,0 +1,282 @@
+﻿'use strict';
+
+var should = require('should'),
+  request = require('supertest'),
+  path = require('path'),
+  mongoose = require('mongoose'),
+  User = mongoose.model('User'),
+  Article = mongoose.model('Article'),
+  express = require(path.resolve('./config/lib/express'));
+
+/**
+ * Globals
+ */
+var app,
+  agent,
+  credentials,
+  user,
+  article;
+
+/**
+ * Article routes tests
+ */
+describe('Article Admin CRUD tests', function () {
+  before(function (done) {
+    // Get application
+    app = express.init(mongoose);
+    agent = request.agent(app);
+
+    done();
+  });
+
+  beforeEach(function (done) {
+    // Create user credentials
+    credentials = {
+      username: 'username',
+      password: 'M3@n.jsI$Aw3$0m3'
+    };
+
+    // Create a new user
+    user = new User({
+      firstName: 'Full',
+      lastName: 'Name',
+      displayName: 'Full Name',
+      email: 'test@test.com',
+      roles: ['user', 'admin'],
+      username: credentials.username,
+      password: credentials.password,
+      provider: 'local'
+    });
+
+    // Save a user to the test db and create new article
+    user.save(function () {
+      article = {
+        title: 'Article Title',
+        content: 'Article Content'
+      };
+
+      done();
+    });
+  });
+
+  it('should be able to save an article if logged in', function (done) {
+    agent.post('/api/auth/signin')
+      .send(credentials)
+      .expect(200)
+      .end(function (signinErr, signinRes) {
+        // Handle signin error
+        if (signinErr) {
+          return done(signinErr);
+        }
+
+        // Get the userId
+        var userId = user.id;
+
+        // Save a new article
+        agent.post('/api/articles')
+          .send(article)
+          .expect(200)
+          .end(function (articleSaveErr, articleSaveRes) {
+            // Handle article save error
+            if (articleSaveErr) {
+              return done(articleSaveErr);
+            }
+
+            // Get a list of articles
+            agent.get('/api/articles')
+              .end(function (articlesGetErr, articlesGetRes) {
+                // Handle article save error
+                if (articlesGetErr) {
+                  return done(articlesGetErr);
+                }
+
+                // Get articles list
+                var articles = articlesGetRes.body;
+
+                // Set assertions
+                (articles[0].user._id).should.equal(userId);
+                (articles[0].title).should.match('Article Title');
+
+                // Call the assertion callback
+                done();
+              });
+          });
+      });
+  });
+
+  it('should be able to update an article if signed in', function (done) {
+    agent.post('/api/auth/signin')
+      .send(credentials)
+      .expect(200)
+      .end(function (signinErr, signinRes) {
+        // Handle signin error
+        if (signinErr) {
+          return done(signinErr);
+        }
+
+        // Get the userId
+        var userId = user.id;
+
+        // Save a new article
+        agent.post('/api/articles')
+          .send(article)
+          .expect(200)
+          .end(function (articleSaveErr, articleSaveRes) {
+            // Handle article save error
+            if (articleSaveErr) {
+              return done(articleSaveErr);
+            }
+
+            // Update article title
+            article.title = 'WHY YOU GOTTA BE SO MEAN?';
+
+            // Update an existing article
+            agent.put('/api/articles/' + articleSaveRes.body._id)
+              .send(article)
+              .expect(200)
+              .end(function (articleUpdateErr, articleUpdateRes) {
+                // Handle article update error
+                if (articleUpdateErr) {
+                  return done(articleUpdateErr);
+                }
+
+                // Set assertions
+                (articleUpdateRes.body._id).should.equal(articleSaveRes.body._id);
+                (articleUpdateRes.body.title).should.match('WHY YOU GOTTA BE SO MEAN?');
+
+                // Call the assertion callback
+                done();
+              });
+          });
+      });
+  });
+
+  it('should not be able to save an article if no title is provided', function (done) {
+    // Invalidate title field
+    article.title = '';
+
+    agent.post('/api/auth/signin')
+      .send(credentials)
+      .expect(200)
+      .end(function (signinErr, signinRes) {
+        // Handle signin error
+        if (signinErr) {
+          return done(signinErr);
+        }
+
+        // Get the userId
+        var userId = user.id;
+
+        // Save a new article
+        agent.post('/api/articles')
+          .send(article)
+          .expect(400)
+          .end(function (articleSaveErr, articleSaveRes) {
+            // Set message assertion
+            (articleSaveRes.body.message).should.match('Title cannot be blank');
+
+            // Handle article save error
+            done(articleSaveErr);
+          });
+      });
+  });
+
+  it('should be able to delete an article if signed in', function (done) {
+    agent.post('/api/auth/signin')
+      .send(credentials)
+      .expect(200)
+      .end(function (signinErr, signinRes) {
+        // Handle signin error
+        if (signinErr) {
+          return done(signinErr);
+        }
+
+        // Get the userId
+        var userId = user.id;
+
+        // Save a new article
+        agent.post('/api/articles')
+          .send(article)
+          .expect(200)
+          .end(function (articleSaveErr, articleSaveRes) {
+            // Handle article save error
+            if (articleSaveErr) {
+              return done(articleSaveErr);
+            }
+
+            // Delete an existing article
+            agent.delete('/api/articles/' + articleSaveRes.body._id)
+              .send(article)
+              .expect(200)
+              .end(function (articleDeleteErr, articleDeleteRes) {
+                // Handle article error error
+                if (articleDeleteErr) {
+                  return done(articleDeleteErr);
+                }
+
+                // Set assertions
+                (articleDeleteRes.body._id).should.equal(articleSaveRes.body._id);
+
+                // Call the assertion callback
+                done();
+              });
+          });
+      });
+  });
+
+  it('should be able to get a single article if signed in and verify the custom "isCurrentUserOwner" field is set to "true"', function (done) {
+    // Create new article model instance
+    article.user = user;
+    var articleObj = new Article(article);
+
+    agent.post('/api/auth/signin')
+      .send(credentials)
+      .expect(200)
+      .end(function (signinErr, signinRes) {
+        // Handle signin error
+        if (signinErr) {
+          return done(signinErr);
+        }
+
+        // Get the userId
+        var userId = user.id;
+
+        // Save a new article
+        agent.post('/api/articles')
+          .send(article)
+          .expect(200)
+          .end(function (articleSaveErr, articleSaveRes) {
+            // Handle article save error
+            if (articleSaveErr) {
+              return done(articleSaveErr);
+            }
+
+            // Get the article
+            agent.get('/api/articles/' + articleSaveRes.body._id)
+              .expect(200)
+              .end(function (articleInfoErr, articleInfoRes) {
+                // Handle article error
+                if (articleInfoErr) {
+                  return done(articleInfoErr);
+                }
+
+                // Set assertions
+                (articleInfoRes.body._id).should.equal(articleSaveRes.body._id);
+                (articleInfoRes.body.title).should.equal(article.title);
+
+                // Assert that the "isCurrentUserOwner" field is set to true since the current User created it
+                (articleInfoRes.body.isCurrentUserOwner).should.equal(true);
+
+                // Call the assertion callback
+                done();
+              });
+          });
+      });
+  });
+
+  afterEach(function (done) {
+    User.remove().exec(function () {
+      Article.remove().exec(done);
+    });
+  });
+});


### PR DESCRIPTION
This is a work in progress, but is intended to gather feedback. There has been talk of separating the Articles views between authenticated User's and non-authenticated *Guests*. This is an attempt to explore going down this road. However, it turned into more of a *Public* states exploration :) 

I know there is competing changes to the Menu' service; #780 . I feel like the `shouldRender` method has been batted around lately. Once we determine how to proceed with implementing these desired features, I will adjust this PR to reflect the solution to the Menu's service refactoring. I think the difficulty in working with the `shouldRender` with these types of modifications, again shows the need for refactoring the Menu service.

@rhutchison @codydaig @trainerbill What do y'all think of this approach? Adding the Public route to the Core config felt a little funny. But it could be a decent solution. This would allow us to create *Public* routes for other modules.