### PR TITLE
Adding coverage report for server-side tests using istanbul

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/meanjs/mean?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/meanjs/mean.svg?branch=master)](https://travis-ci.org/meanjs/mean)
 [![Dependencies Status](https://david-dm.org/meanjs/mean.svg)](https://david-dm.org/meanjs/mean)
+[![Coverage Status](https://coveralls.io/repos/meanjs/mean/badge.svg?branch=master&service=github)](https://coveralls.io/github/meanjs/mean?branch=master)
 
 MEAN.JS is a full-stack JavaScript open-source solution, which provides a solid starting point for [MongoDB](http://www.mongodb.org/), [Node.js](http://www.nodejs.org/), [Express](http://expressjs.com/), and [AngularJS](http://angularjs.org/) based applications. The idea is to solve the common issues with connecting those frameworks, build a robust framework to support daily development needs, and help developers use better practices while working with popular JavaScript components.
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -184,10 +184,11 @@ module.exports = function (grunt) {
           coverage: true,
           require: 'test.js',
           coverageFolder: 'coverage',
+          reportFormats: ['cobertura','lcovonly'],
           check: {
             lines: 40,
             statements: 40
-          } 
+          }
         }
       }
     },
@@ -217,6 +218,15 @@ module.exports = function (grunt) {
         }
       }
     }
+  });
+
+  grunt.event.on('coverage', function(lcovFileContents, done) {
+    require('coveralls').handleInput(lcovFileContents, function(err) {
+      if (err) {
+        return done(err);
+      }
+      done();
+    });
   });
 
   // Load NPM tasks

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -176,6 +176,21 @@ module.exports = function (grunt) {
         reporter: 'spec'
       }
     },
+    mocha_istanbul: {
+      coverage: {
+        src: testAssets.tests.server,
+        options: {
+          print: 'detail',
+          coverage: true,
+          require: 'test.js',
+          coverageFolder: 'coverage',
+          check: {
+            lines: 40,
+            statements: 40
+          } 
+        }
+      }
+    },
     karma: {
       unit: {
         configFile: 'karma.conf.js'
@@ -252,6 +267,9 @@ module.exports = function (grunt) {
   grunt.registerTask('test', ['env:test', 'lint', 'mkdir:upload', 'copy:localConfig', 'server', 'mochaTest', 'karma:unit']);
   grunt.registerTask('test:server', ['env:test', 'lint', 'server', 'mochaTest']);
   grunt.registerTask('test:client', ['env:test', 'lint', 'server', 'karma:unit']);
+  // Run project coverage
+  grunt.registerTask('coverage', ['env:test', 'lint', 'mocha_istanbul:coverage']);
+
   // Run the project in development mode
   grunt.registerTask('default', ['env:dev', 'lint', 'mkdir:upload', 'copy:localConfig', 'concurrent:default']);
 

--- a/modules/articles/tests/server/article.server.model.tests.js
+++ b/modules/articles/tests/server/article.server.model.tests.js
@@ -40,6 +40,7 @@ describe('Article Model Unit Tests:', function () {
 
   describe('Method Save', function () {
     it('should be able to save without problems', function (done) {
+      this.timeout(10000);
       return article.save(function (err) {
         should.not.exist(err);
         done();

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "grunt-env": "~0.4.4",
     "grunt-karma": "~0.11.2",
     "grunt-mocha-test": "~0.12.7",
+    "grunt-mocha-istanbul": "^2.4.0",
     "grunt-ng-annotate": "^1.0.1",
     "grunt-node-inspector": "~0.2.0",
     "grunt-nodemon": "~0.4.0",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "load-grunt-tasks": "^3.2.0",
     "run-sequence": "^1.1.1",
     "should": "^7.0.1",
-    "supertest": "^1.0.1"
+    "supertest": "^1.0.1",
+    "coveralls": "^2.11.4"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var app, db, config;
+
+var path = require('path');
+var app = require(path.resolve('./config/lib/app'));
+
+app.init(function (app, db, config) {
+	console.log('Initialized test automation');
+});

--- a/test.js
+++ b/test.js
@@ -3,11 +3,11 @@
 /**
  * Module dependencies.
  */
-var app, db, config;
+var app;
 
 var path = require('path');
 var app = require(path.resolve('./config/lib/app'));
 
-app.init(function (app, db, config) {
-	console.log('Initialized test automation');
+app.init(function () {
+  console.log('Initialized test automation');
 });


### PR DESCRIPTION
Code coverage is now built-in to our project and grunt tasks!

![meanjs-code-coverage-2](https://cloud.githubusercontent.com/assets/316371/9290945/2b2d8c10-43ae-11e5-8319-03ddb3762350.PNG)

and further results:

![meanjs-code-coverage-1](https://cloud.githubusercontent.com/assets/316371/9290946/2dc888a8-43ae-11e5-90c7-5b8fa57c5a80.PNG)

To run the code coverage simply execute:
```bash
grunt coverage
```

Addresses:
* https://github.com/meanjs/mean/pull/569
* https://github.com/meanjs/mean/pull/760