### PR TITLE
Fixed bug with Socket IO session

### DIFF
--- a/config/lib/socket.io.js
+++ b/config/lib/socket.io.js
@@ -71,10 +71,15 @@ module.exports = function (app, db) {
     // Use the 'cookie-parser' module to parse the request cookies
     cookieParser(config.sessionSecret)(socket.request, {}, function (err) {
       // Get the session id from the request cookies
-      var sessionId = socket.request.signedCookies['connect.sid'];
+      var sessionId = socket.request.signedCookies ? socket.request.signedCookies[config.sessionKey] : undefined;
+
+      if (!sessionId) return next(new Error('sessionId was not found in socket.request'), false);
 
       // Use the mongoStorage instance to get the Express session information
       mongoStore.get(sessionId, function (err, session) {
+        if (err) return next(err, false);
+        if (!session) return next(new Error('session was not found for ' + sessionId), false);
+
         // Set the Socket.io session information
         socket.request.session = session;
 


### PR DESCRIPTION
New enhancements to the Express session, added "sessionId" as the new
default session key. Previously, the express session was using the
default "connect.sid" key. This caused the Socket configuration to be
unable to find the session id, thus causing issues with the Socket. One
such issue, was that the same Socket would be used for all users
connected to the server.

This also adds a bit more error handling of the Socket server
configuration.