### PR TITLE
fix default session cookie maxAge

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -11,7 +11,7 @@ module.exports = {
   templateEngine: 'swig',
   // Session details
   // session expiration is set by default to 24 hours
-  sessionExpiration: 24 * (60 * 1000),
+  sessionExpiration: 24 * (60 * 60 * 1000),
   // sessionSecret should be changed for security measures and concerns
   sessionSecret: 'MEAN',
   // sessionKey is set to the generic sessionId key used by PHP applications


### PR DESCRIPTION
Set default session cookie maxAge from 24 minutes to 24 hours.

Sorry @lirantal only noticed now :P