### PR TITLE
Corrected 'prod' task in gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -191,5 +191,5 @@ gulp.task('debug', function(done) {
 
 // Run the project in production mode
 gulp.task('prod', function(done) {
-  runSequence('build', 'lint', ['nodemon', 'watch'], done);
+  runSequence('build', 'env:prod', 'lint', ['nodemon', 'watch'], done);
 });


### PR DESCRIPTION
The current gulpfile 'prod' task runs the 'build' subtask which sets the environment variable to development.  This pull request correctly sets the environment variable to production following completion of the build subtask.