### PR TITLE
Fixed issue where if local.js exists then grunt test will run on that…

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -159,9 +159,14 @@ var initGlobalConfig = function () {
   var environmentConfig = require(path.join(process.cwd(), 'config/env/', process.env.NODE_ENV)) || {};
 
   // Merge config files
-  var envConf = _.merge(defaultConfig, environmentConfig);
+  var config = _.merge(defaultConfig, environmentConfig);
 
-  var config = _.merge(envConf, (fs.existsSync(path.join(process.cwd(), 'config/env/local.js')) && require(path.join(process.cwd(), 'config/env/local.js'))) || {});
+  // We only extend the config object with the local.js custom/local environment if we are on
+  // production or development environment. If test environment is used we don't merge it with local.js
+  // to avoid running test suites on a prod/dev environment (which delete records and make modifications)
+  if (process.env.NODE_ENV !== 'test') {
+    config = _.merge(config, (fs.existsSync(path.join(process.cwd(), 'config/env/local.js')) && require(path.join(process.cwd(), 'config/env/local.js'))) || {});  
+  }
 
   // Initialize global globbed files
   initGlobalConfigFiles(config, assets);


### PR DESCRIPTION
… environment config and possibly delete collections

We only extend the config object with the local.js custom/local environment if we are on production or development environment. If test environment is used we don't merge it with local.js to avoid running test suites on a prod/dev environment (which delete records and make modifications)