### PR TITLE
[fix] Was storing a 6 char password in plain text [fixes #829]

### DIFF
--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -107,7 +107,7 @@ var UserSchema = new Schema({
  * Hook a pre save method to hash the password
  */
 UserSchema.pre('save', function (next) {
-  if (this.password && this.isModified('password') && this.password.length > 6) {
+  if (this.password && this.isModified('password') && this.password.length >= 6) {
     this.salt = crypto.randomBytes(16).toString('base64');
     this.password = this.hashPassword(this.password);
   }

--- a/modules/users/tests/server/user.server.model.tests.js
+++ b/modules/users/tests/server/user.server.model.tests.js
@@ -155,6 +155,33 @@ describe('User Model Unit Tests:', function () {
 
   });
 
+  it('should not save the password in plain text', function (done) {
+    var _user = new User(user);
+    var passwordBeforeSave = _user.password;
+    _user.save(function (err) {
+      should.not.exist(err);
+      _user.password.should.not.equal(passwordBeforeSave);
+      _user.remove(function(err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+  });
+
+  it('should not save the password in plain text (6 char password)', function (done) {
+    var _user = new User(user);
+    _user.password = '123456';
+    var passwordBeforeSave = _user.password;
+    _user.save(function (err) {
+      should.not.exist(err);
+      _user.password.should.not.equal(passwordBeforeSave);
+      _user.remove(function(err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+  });
+
   describe("User E-mail Validation Tests", function() {
     it('should not allow invalid email address - "123"', function (done) {
       var _user = new User(user);


### PR DESCRIPTION
Fixes #829.

If the password was exactly 6 characters long, the password would not get hashed and was being stored in the database as plain text. I added a couple tests to ensure the password wasn't being stored in plain text as well as fixed the logic that was skipping over the password hashing. 

Thanks @sparshy! :-D