### PR TITLE
[fix] Fixed Facebook Auth [Closes #697]

### DIFF
--- a/modules/users/server/config/strategies/facebook.js
+++ b/modules/users/server/config/strategies/facebook.js
@@ -13,7 +13,7 @@ module.exports = function (config) {
       clientID: config.facebook.clientID,
       clientSecret: config.facebook.clientSecret,
       callbackURL: config.facebook.callbackURL,
-      profileFields: ['id', 'name', 'displayName', 'emails', 'photos'],
+      profileFields: ['id', 'name', 'displayName', 'email', 'photos'],
       passReqToCallback: true
     },
     function (req, accessToken, refreshToken, profile, done) {


### PR DESCRIPTION
Per the Facebook Docs: https://developers.facebook.com/docs/graph-api/reference/v2.3/user

There is no `emails` field, it is only `email`

Closes #697 