### PR TITLE
mask exception route for 404 responses.

### DIFF
--- a/modules/core/client/config/core.client.routes.js
+++ b/modules/core/client/config/core.client.routes.js
@@ -5,7 +5,11 @@ angular.module('core').config(['$stateProvider', '$urlRouterProvider',
   function ($stateProvider, $urlRouterProvider) {
 
     // Redirect to 404 when route not found
-    $urlRouterProvider.otherwise('not-found');
+    $urlRouterProvider.otherwise(function ($injector, $location) {
+      $injector.get('$state').transitionTo('not-found', null, {
+        location: false
+      });
+    });
 
     // Home state routing
     $stateProvider


### PR DESCRIPTION
This will mask the not-found route by showing the not-found page without redirecting to the not-found state.

##### Steps
1. http://localhost:3000/khdshskddsakh

##### Expected
* Route should not change.
* User should see page not found.