### PR TITLE
[hotfix] Fixed User model tests

### DIFF
--- a/modules/users/tests/server/user.server.model.tests.js
+++ b/modules/users/tests/server/user.server.model.tests.js
@@ -86,14 +86,14 @@ describe('User Model Unit Tests:', function () {
     });
 
     it('should be able to update an existing user with valid roles without problems', function (done) {
-      var _user = new User(user);
+      var _user1 = new User(user1);
 
-      _user.save(function (err) {
+      _user1.save(function (err) {
         should.not.exist(err);
-        _user.roles = ['user', 'admin'];
-        _user.save(function (err) {
+        _user1.roles = ['user', 'admin'];
+        _user1.save(function (err) {
           should.not.exist(err);
-          _user.remove(function (err) {
+          _user1.remove(function (err) {
             should.not.exist(err);
             done();
           });
@@ -102,14 +102,14 @@ describe('User Model Unit Tests:', function () {
     });
 
     it('should be able to show an error when trying to update an existing user without a role', function (done) {
-      var _user = new User(user);
+      var _user1 = new User(user1);
 
-      _user.save(function (err) {
+      _user1.save(function (err) {
         should.not.exist(err);
-        _user.roles = [];
-        _user.save(function (err) {
+        _user1.roles = [];
+        _user1.save(function (err) {
           should.exist(err);
-          _user.remove(function (err) {
+          _user1.remove(function (err) {
             should.not.exist(err);
             done();
           });
@@ -118,14 +118,14 @@ describe('User Model Unit Tests:', function () {
     });
 
     it('should be able to show an error when trying to update an existing user with a invalid role', function (done) {
-      var _user = new User(user);
+      var _user1 = new User(user1);
 
-      _user.save(function (err) {
+      _user1.save(function (err) {
         should.not.exist(err);
-        _user.roles = ['invalid-user-role-enum'];
-        _user.save(function (err) {
+        _user1.roles = ['invalid-user-role-enum'];
+        _user1.save(function (err) {
           should.exist(err);
-          _user.remove(function (err) {
+          _user1.remove(function (err) {
             should.not.exist(err);
             done();
           });


### PR DESCRIPTION
@lirantal PR #840 changed the global var `user` to `user1` in the User model server tests. This was merged and then #858 was merged, which was still referencing the global var as `user` in the new *roles* tests. This is causing jshint failures.

This change updates the new *roles* tests to use `user1`