### PR TITLE
Add config options 'domain'

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -67,6 +67,15 @@ var validateEnvironmentVariable = function () {
 };
 
 /**
+ * Validate config.domain is set
+ */
+var validateDomainIsSet = function (config) {
+  if(!config.app.domain){
+    console.log(chalk.red('+ Important warning: config.domain is empty. For security reasons it should be set to the domain of the app.'));
+  }
+};
+
+/**
  * Validate Secure=true parameter can actually be turned on
  * because it requires certs and key files to be available
  */
@@ -186,6 +195,9 @@ var initGlobalConfig = function () {
   // read package.json for MEAN.JS project information
   var pkg = require(path.resolve('./package.json'));
   config.meanjs = pkg;
+
+  // Print a warning if config.domain is not set
+  validateDomainIsSet(config);
 
   // We only extend the config object with the local.js custom/local environment if we are on
   // production or development environment. If test environment is used we don't merge it with local.js

--- a/config/env/default.js
+++ b/config/env/default.js
@@ -5,7 +5,8 @@ module.exports = {
     title: 'MEAN.JS',
     description: 'Full-Stack JavaScript with MongoDB, Express, AngularJS, and Node.js',
     keywords: 'mongodb, express, angularjs, node.js, mongoose, passport',
-    googleAnalyticsTrackingID: process.env.GOOGLE_ANALYTICS_TRACKING_ID || 'GOOGLE_ANALYTICS_TRACKING_ID'
+    googleAnalyticsTrackingID: process.env.GOOGLE_ANALYTICS_TRACKING_ID || 'GOOGLE_ANALYTICS_TRACKING_ID',
+    domain: process.env.DOMAIN
   },
   port: process.env.PORT || 3000,
   templateEngine: 'swig',

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -32,7 +32,8 @@ module.exports = {
     }
   },
   app: {
-    title: defaultEnvConfig.app.title + ' - Development Environment'
+    title: defaultEnvConfig.app.title + ' - Development Environment',
+    domain: process.env.DOMAIN || 'localhost:' + defaultEnvConfig.port
   },
   facebook: {
     clientID: process.env.FACEBOOK_ID || 'APP_ID',

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -33,7 +33,8 @@ module.exports = {
   },
   port: process.env.PORT || 3001,
   app: {
-    title: defaultEnvConfig.app.title + ' - Test Environment'
+    title: defaultEnvConfig.app.title + ' - Test Environment',
+    domain: process.env.DOMAIN || 'localhost:3001'
   },
   facebook: {
     clientID: process.env.FACEBOOK_ID || 'APP_ID',

--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -40,8 +40,9 @@ module.exports.initLocalVariables = function (app) {
 
   // Passing the request url to environment locals
   app.use(function (req, res, next) {
-    res.locals.host = req.protocol + '://' + req.hostname;
-    res.locals.url = req.protocol + '://' + req.headers.host + req.originalUrl;
+    var domain = config.app.domain || req.headers.host;
+    res.locals.host = req.protocol + '://' + domain;
+    res.locals.url = req.protocol + '://' + domain + req.originalUrl;
     next();
   });
 };

--- a/modules/core/server/views/layout.server.view.html
+++ b/modules/core/server/views/layout.server.view.html
@@ -56,7 +56,12 @@
 
   {% if livereload %}
   <!--Livereload script rendered -->
-  <script type="text/javascript" src="{{host}}:35729/livereload.js"></script>
+  <script type="text/javascript">
+    var scriptTag = document.createElement('script');
+    scriptTag.setAttribute('type', 'text/javascript');
+    scriptTag.setAttribute('src', '//' + window.location.hostname + ':35729/livereload.js');
+    document.head.appendChild(scriptTag);
+  </script>
   {% endif %}
 </body>
 


### PR DESCRIPTION
The value will be used when the backend has to generate urls which
point to the app. Using the hostname sent in the HTTP header is
dangerous since an attacker could send a request with a spoofed
HTTP header (HTTP Host header attack).

If the config is not set a loud warning is printed on startup and
the hostname of the HTTP header is used nevertheless.