### PR TITLE
0.4.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "meanjs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Fullstack JavaScript with MongoDB, Express, AngularJS, and Node.js.",
   "dependencies": {
     "bootstrap": "~3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meanjs",
   "description": "Full-Stack JavaScript with MongoDB, Express, AngularJS, and Node.js.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "author": "https://github.com/meanjs/mean/graphs/contributors",
   "license": "MIT",


### PR DESCRIPTION
@lirantal We should probably bump the version on the package.json to match the latest release. This should be included in the 0.4.1 release tag if possible.