### PR TITLE
[hotfix] JSHINT newcap option [closes #882]

### DIFF
--- a/modules/articles/server/policies/articles.server.policy.js
+++ b/modules/articles/server/policies/articles.server.policy.js
@@ -5,6 +5,7 @@
  */
 var acl = require('acl');
 
+/*jshint -W055 */ // Added due to https://github.com/meanjs/mean/issues/882
 // Using the memory backend
 acl = new acl(new acl.memoryBackend());
 

--- a/modules/users/server/policies/admin.server.policy.js
+++ b/modules/users/server/policies/admin.server.policy.js
@@ -5,6 +5,7 @@
  */
 var acl = require('acl');
 
+/*jshint -W055 */ // Added due to https://github.com/meanjs/mean/issues/882 
 // Using the memory backend
 acl = new acl(new acl.memoryBackend());
 


### PR DESCRIPTION
Added the `newcap` option back to `.jshintrc` fixing to #882. I'm still
unclear as to the exact cause. See the corresponding issue for more
detail.

@lirantal @ilanbiala @codydaig 