### PR TITLE
Adding another job for Travis CI to run the `grunt coverage` task on every build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - npm i nsp -g
 after_script:
   - nsp audit-package
+  - grunt coverage
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
This addresses the code coverage running as part of our CI in https://github.com/meanjs/mean/pull/811