### PR TITLE
Adding MEAN.JS version information as part of the startup info when app loads

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -161,6 +161,10 @@ var initGlobalConfig = function () {
   // Merge config files
   var config = _.merge(defaultConfig, environmentConfig);
 
+  // read package.json for MEAN.JS project information
+  var pkg = require(path.resolve('./package.json'));
+  config.meanjs = pkg;
+
   // We only extend the config object with the local.js custom/local environment if we are on
   // production or development environment. If test environment is used we don't merge it with local.js
   // to avoid running test suites on a prod/dev environment (which delete records and make modifications)

--- a/config/lib/app.js
+++ b/config/lib/app.js
@@ -46,6 +46,7 @@ module.exports.start = function start(callback) {
       if (process.env.NODE_ENV === 'secure') {
         console.log(chalk.green('HTTPs:\t\t\t\ton'));
       }
+      console.log(chalk.green('MEAN.JS version:\t\t\t' + config.meanjs.version));
       console.log('--');
 
       if (callback) callback(app, db, config);

--- a/config/lib/app.js
+++ b/config/lib/app.js
@@ -46,7 +46,9 @@ module.exports.start = function start(callback) {
       if (process.env.NODE_ENV === 'secure') {
         console.log(chalk.green('HTTPs:\t\t\t\ton'));
       }
-      console.log(chalk.green('MEAN.JS version:\t\t\t' + config.meanjs.version));
+      console.log(chalk.green('App version:\t\t\t' + config.meanjs.version));
+      if (config.meanjs['meanjs-version'])
+        console.log(chalk.green('MEAN.JS version:\t\t\t' + config.meanjs['meanjs-version']));
       console.log('--');
 
       if (callback) callback(app, db, config);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "meanjs",
   "description": "Full-Stack JavaScript with MongoDB, Express, AngularJS, and Node.js.",
   "version": "0.4.1",
+  "meanjs-version": "0.4.1",
   "private": false,
   "author": "https://github.com/meanjs/mean/graphs/contributors",
   "license": "MIT",


### PR DESCRIPTION
I've been thinking it would be great if we can display the project version number when the app starts as that will easily allow other devs and users to clearly see which MEAN.JS release they are on.

We often get a lot of bug requests and this is usually the first version that comes up...

![image](https://cloud.githubusercontent.com/assets/316371/9700526/bec05a1e-540e-11e5-9726-25c172075461.png)

WDYT?