### PR TITLE
Adding sample config/ directory for articles module

### DIFF
--- a/modules/articles/server/config/articles.server.config.js
+++ b/modules/articles/server/config/articles.server.config.js
@@ -1,0 +1,14 @@
+  'user strict';
+
+/**
+ * Module dependencies
+ */
+var path = require('path'),
+  config = require(path.resolve('./config/config'));
+
+/**
+ * Module init function.
+ */
+module.exports = function (app, db) {
+
+};


### PR DESCRIPTION
Dummy config directory for the articles module to make it easier for developers to understand and realize there's an actual per-module config/ directory/files that can be added

This came up from my gitter conversation with @trainerbill who was asking about modularizing the configuration approach so that modules can have their own config tasks and didn't realize it already existed and requested to have a 'sample' directory/file for the articles module as a general guide.