### PR TITLE
Fix redirection to previous state after required authentication

### DIFF
--- a/modules/core/client/app/init.js
+++ b/modules/core/client/app/init.js
@@ -30,7 +30,9 @@ angular.module(ApplicationConfiguration.applicationModuleName).run(function ($ro
         if (Authentication.user !== undefined && typeof Authentication.user === 'object') {
           $state.go('forbidden');
         } else {
-          $state.go('authentication.signin');
+          $state.go('authentication.signin').then(function () {
+            storePreviousState(toState, toParams);
+          });
         }
       }
     }
@@ -38,14 +40,20 @@ angular.module(ApplicationConfiguration.applicationModuleName).run(function ($ro
 
   // Record previous state
   $rootScope.$on('$stateChangeSuccess', function (event, toState, toParams, fromState, fromParams) {
-    if (!fromState.data || !fromState.data.ignoreState) {
+    storePreviousState(fromState, fromParams);
+  });
+
+  // Store previous state
+  function storePreviousState(state, params) {
+    // only store this state if it shouldn't be ignored 
+    if (!state.data || !state.data.ignoreState) {
       $state.previous = {
-        state: fromState,
-        params: fromParams,
-        href: $state.href(fromState, fromParams)
+        state: state,
+        params: params,
+        href: $state.href(state, params)
       };
     }
-  });
+  }
 });
 
 //Then define the init function for starting up the application

--- a/modules/users/tests/client/authentication.client.controller.tests.js
+++ b/modules/users/tests/client/authentication.client.controller.tests.js
@@ -8,6 +8,7 @@
       scope,
       $httpBackend,
       $stateParams,
+      $state,
       $location;
 
     beforeEach(function () {
@@ -58,6 +59,32 @@
           expect(scope.authentication.user).toEqual('Fred');
           expect($location.url()).toEqual('/');
         });
+
+        it('should be redirected to previous state after successful login',
+          inject(function (_$state_) {
+            $state = _$state_;
+            $state.previous = {
+              state: {
+                name: 'articles.create'
+              },
+              params: {},
+              href: '/articles/create'
+            };
+
+            spyOn($state, 'transitionTo');
+            spyOn($state, 'go');
+
+            // Test expected GET request
+            $httpBackend.when('POST', '/api/auth/signin').respond(200, 'Fred');
+
+            scope.signin(true);
+            $httpBackend.flush();
+
+            // Test scope value
+            expect($state.go).toHaveBeenCalled();
+            expect($state.go).toHaveBeenCalledWith($state.previous.state.name, $state.previous.params);
+
+          }));
 
         it('should fail to log in with nothing', function () {
           // Test expected POST request


### PR DESCRIPTION
`$stateChangeSuccess` event should be signaled in order to allow "recording" of previous state. 

This part of the implementation was missing, I just realized that.