### PR TITLE
Supporting NodeJS v4 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
+  - 0.10
+  - 0.12
+  - 4
 env:
   - NODE_ENV=travis
 matrix:
-  - allow_failures:
-    - node_js: "4"
+  allow_failures:
+    - node_js: 4
 services:
   - mongodb
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - 0.10
   - 0.12
@@ -24,3 +25,8 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
+cache:
+  apt: true
+  directories:
+  - node_modules/
+  - public/lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,12 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "4"
 env:
   - NODE_ENV=travis
+matrix:
+  - allow_failures:
+    - node_js: "4"
 services:
   - mongodb
 before_install:


### PR DESCRIPTION
Adding support for nodejs v4 and allowing it to fail without failing the complete build for CI.
Closes #902.