### PR TITLE
[bugfix] Fixes bug with db seed user passwords

### DIFF
--- a/config/lib/seed.js
+++ b/config/lib/seed.js
@@ -35,7 +35,7 @@ if (process.env.NODE_ENV === 'production') {
   //Add Local Admin
   User.find({username: 'admin'}, function (err, users) {
     if (users.length === 0) {
-      var password = crypto.randomBytes(64).toString('hex').slice(1, 20);
+      var password = User.generateRandomPassphrase();
       seedAdmin.password = password;
       var user = new User(seedAdmin);
       // Then save the user
@@ -53,7 +53,7 @@ if (process.env.NODE_ENV === 'production') {
 } else {
   //Add Local User
   User.find({username: 'user'}).remove(function () {
-    var password = crypto.randomBytes(64).toString('hex').slice(1, 20);
+    var password = User.generateRandomPassphrase();
     seedUser.password = password;
     var user = new User(seedUser);
     // Then save the user
@@ -69,7 +69,7 @@ if (process.env.NODE_ENV === 'production') {
 
   //Add Local Admin
   User.find({username: 'admin'}).remove(function () {
-    var password = crypto.randomBytes(64).toString('hex').slice(1, 20);
+    var password = User.generateRandomPassphrase();
     seedAdmin.password = password;
     var user = new User(seedAdmin);
     // Then save the user

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -7,6 +7,7 @@ var mongoose = require('mongoose'),
   Schema = mongoose.Schema,
   crypto = require('crypto'),
   validator = require('validator'),
+  generatePassword = require('generate-password'),
   owasp = require('owasp-password-strength-test');
 
 /**
@@ -164,6 +165,39 @@ UserSchema.statics.findUniqueUsername = function (username, suffix, callback) {
       callback(null);
     }
   });
+};
+
+/**
+* Generates a random passphrase that passes the owasp test.
+* Returns a promise that resolves with the generated passphrase, or rejects with an error if something goes wrong.
+* NOTE: Passphrases are only tested against the required owasp strength tests, and not the optional tests.
+*/
+UserSchema.statics.generateRandomPassphrase = function () {
+  var password = '';
+  var repeatingCharacters = new RegExp('(.)\\1{2,}', 'g');
+
+  // iterate until the we have a valid passphrase. 
+  // NOTE: Should rarely iterate more than once, but we need this to ensure no repeating characters are present.
+  while (password.length < 20 || repeatingCharacters.test(password)) {
+    // build the random password
+    password = generatePassword.generate({
+      length: Math.floor(Math.random() * (20)) + 20, // randomize length between 20 and 40 characters
+      numbers: true,
+      symbols: false,
+      uppercase: true,
+      excludeSimilarCharacters: true,
+    });
+
+    // check if we need to remove any repeating characters.
+    password = password.replace(repeatingCharacters, '');
+  }
+
+  // Send the passphrase back unless it fails to pass the strength test
+  if (owasp.test(password).errors.length) {
+    return null;
+  } else {
+    return password;
+  }
 };
 
 mongoose.model('User', UserSchema);

--- a/modules/users/tests/server/user.server.model.tests.js
+++ b/modules/users/tests/server/user.server.model.tests.js
@@ -228,6 +228,15 @@ describe('User Model Unit Tests:', function () {
       });
     });
 
+    it('should validate a randomly generated passphrase from the static schema method', function () {
+      var _user1 = new User(user1);
+      _user1.password = User.generateRandomPassphrase();
+
+      _user1.validate(function (err) {
+        should.not.exist(err);
+      });
+    });
+
     it('should validate when the password is undefined', function () {
       var _user1 = new User(user1);
       _user1.password = undefined;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "express": "^4.13.1",
     "express-session": "^1.11.3",
     "forever": "~0.14.2",
+    "generate-password": "^1.1.1",
     "glob": "^5.0.13",
     "grunt": "0.4.5",
     "grunt-cli": "~0.1.13",


### PR DESCRIPTION
@lirantal This PR is an alternative to #921 You may prefer this one as it is much simpler and has very little changes to the db seed configuration. I know you want this fix merged ASAP. Whatever your preference, is fine by me. This PR & #921 work to fix the bug.

Added a static schema method to the User schema to generate a random
passphrase, that passes the owasp strength test.

Updated the db seed configuration to use a randomly generated passphrase
from the new User schema method, as the passwords for the seeded users.

Added the generate-password package to the project.