### PR TITLE
Mocha test timeouts [fixes #955]

### DIFF
--- a/modules/articles/tests/server/article.server.model.tests.js
+++ b/modules/articles/tests/server/article.server.model.tests.js
@@ -17,6 +17,8 @@ var user, article;
  * Unit tests
  */
 describe('Article Model Unit Tests:', function () {
+  this.timeout(10000);
+
   beforeEach(function (done) {
     user = new User({
       firstName: 'Full',

--- a/modules/articles/tests/server/article.server.routes.tests.js
+++ b/modules/articles/tests/server/article.server.routes.tests.js
@@ -17,6 +17,8 @@ var app, agent, credentials, user, article;
  * Article routes tests
  */
 describe('Article CRUD tests', function () {
+  this.timeout(10000);
+
   before(function (done) {
     // Get application
     app = express.init(mongoose);

--- a/modules/chat/tests/server/chat.socket.tests.js
+++ b/modules/chat/tests/server/chat.socket.tests.js
@@ -4,5 +4,7 @@
  * Chat socket tests
  */
 describe('Chat Socket Tests:', function () {
+  this.timeout(10000);
+
   // TODO: Add chat socket tests
 });

--- a/modules/core/tests/server/core.server.config.tests.js
+++ b/modules/core/tests/server/core.server.config.tests.js
@@ -11,6 +11,7 @@ var should = require('should'),
   seed = require(path.resolve('./config/lib/seed'));
 
 describe('Configuration tests', function () {
+  this.timeout(10000);
 
   describe('Testing default seedDB:', function () {
     before(function(done) {

--- a/modules/users/tests/server/user.server.model.tests.js
+++ b/modules/users/tests/server/user.server.model.tests.js
@@ -16,6 +16,8 @@ var user1, user2, user3;
  * Unit tests
  */
 describe('User Model Unit Tests:', function () {
+  this.timeout(10000);
+
   before(function () {
     user1 = {
       firstName: 'Full',

--- a/modules/users/tests/server/user.server.routes.tests.js
+++ b/modules/users/tests/server/user.server.routes.tests.js
@@ -16,6 +16,8 @@ var app, agent, credentials, user, _user, admin;
  * User routes tests
  */
 describe('User CRUD tests', function () {
+  this.timeout(10000);
+
   before(function (done) {
     // Get application
     app = express.init(mongoose);


### PR DESCRIPTION
Added a timeout of 10000 ms to each server test file. This is an attempt
to solve the timeout issues that we're experiencing with the Mocha
tests. Especially, this is hoping to address the build fails that are
caused by such timeouts.

Issue is described in https://github.com/meanjs/mean/issues/955