### PR TITLE
[bug] Solves User model validation issue with tests [fixes #966]

### DIFF
--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -116,7 +116,7 @@ UserSchema.pre('save', function (next) {
  * Hook a pre validate method to test the local password
  */
 UserSchema.pre('validate', function (next) {
-  if (this.provider === 'local' && this.password) {
+  if (this.provider === 'local' && this.password && this.isModified('password')) {
     var result = owasp.test(this.password);
     if (result.errors.length) {
       var error = result.errors.join(' ');


### PR DESCRIPTION
This solves the issue of the User model's `pre('validate')` method, attempting to validate against a password that was not modified.

Adds the `this.isModified('password')` check to the condition.