### PR TITLE
Global Mocha timeout

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -173,7 +173,8 @@ module.exports = function (grunt) {
     mochaTest: {
       src: testAssets.tests.server,
       options: {
-        reporter: 'spec'
+        reporter: 'spec',
+        timeout: 10000
       }
     },
     mocha_istanbul: {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -172,7 +172,8 @@ gulp.task('mocha', function (done) {
     // Run the tests
     gulp.src(testAssets.tests.server)
       .pipe(plugins.mocha({
-        reporter: 'spec'
+        reporter: 'spec',
+        timeout: 10000
       }))
       .on('error', function (err) {
         // If an error occurs, save it

--- a/modules/articles/tests/server/article.server.model.tests.js
+++ b/modules/articles/tests/server/article.server.model.tests.js
@@ -17,7 +17,6 @@ var user, article;
  * Unit tests
  */
 describe('Article Model Unit Tests:', function () {
-  this.timeout(10000);
 
   beforeEach(function (done) {
     user = new User({

--- a/modules/articles/tests/server/article.server.routes.tests.js
+++ b/modules/articles/tests/server/article.server.routes.tests.js
@@ -17,7 +17,6 @@ var app, agent, credentials, user, article;
  * Article routes tests
  */
 describe('Article CRUD tests', function () {
-  this.timeout(10000);
 
   before(function (done) {
     // Get application

--- a/modules/chat/tests/server/chat.socket.tests.js
+++ b/modules/chat/tests/server/chat.socket.tests.js
@@ -4,7 +4,6 @@
  * Chat socket tests
  */
 describe('Chat Socket Tests:', function () {
-  this.timeout(10000);
 
   // TODO: Add chat socket tests
 });

--- a/modules/core/tests/server/core.server.config.tests.js
+++ b/modules/core/tests/server/core.server.config.tests.js
@@ -11,7 +11,6 @@ var should = require('should'),
   seed = require(path.resolve('./config/lib/seed'));
 
 describe('Configuration Tests:', function () {
-  this.timeout(10000);
 
   describe('Testing default seedDB', function () {
     before(function(done) {

--- a/modules/users/tests/server/user.server.model.tests.js
+++ b/modules/users/tests/server/user.server.model.tests.js
@@ -16,7 +16,6 @@ var user1, user2, user3;
  * Unit tests
  */
 describe('User Model Unit Tests:', function () {
-  this.timeout(10000);
 
   before(function () {
     user1 = {

--- a/modules/users/tests/server/user.server.routes.tests.js
+++ b/modules/users/tests/server/user.server.routes.tests.js
@@ -16,7 +16,6 @@ var app, agent, credentials, user, _user, admin;
  * User routes tests
  */
 describe('User CRUD tests', function () {
-  this.timeout(10000);
 
   before(function (done) {
     // Get application


### PR DESCRIPTION
Added the timeout option to the Mocha grunt task; set to 10000.

Removed the individual test suite timeouts, for all server tests.

As discussed in #964 