### PR TITLE
Global Mocha timeout option for Gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -172,7 +172,8 @@ gulp.task('mocha', function (done) {
     // Run the tests
     gulp.src(testAssets.tests.server)
       .pipe(plugins.mocha({
-        reporter: 'spec'
+        reporter: 'spec',
+        timeout: 10000
       }))
       .on('error', function (err) {
         // If an error occurs, save it


### PR DESCRIPTION
Added the timeout option for the Mocha gulp task.

This the Gulp counterpart to #972 & #964 
