### PR TITLE
[bug] Logger wasn't using the logger config option

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -70,7 +70,7 @@ module.exports.initMiddleware = function (app) {
   // Environment dependent middleware
   if (process.env.NODE_ENV === 'development') {
     // Enable logger (morgan)
-    app.use(morgan('dev'));
+    app.use(morgan(config.log.format, config.log.options));
 
     // Disable views cache
     app.set('view cache', false);


### PR DESCRIPTION
To fix an issue that I brought up in #975. 

The morgan logger in express wasn't utilizing the logger config options, so this PR fixes that.