### PR TITLE
Adding karma coverage to grunt

### DIFF
--- a/config/env/test.js
+++ b/config/env/test.js
@@ -80,5 +80,7 @@ module.exports = {
         roles: ['user', 'admin']
       }
     }
-  }
+  },
+  // This config is set to true during grunt coverage
+  coverage: process.env.COVERAGE || false
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -6,6 +6,7 @@
 var _ = require('lodash'),
   defaultAssets = require('./config/assets/default'),
   testAssets = require('./config/assets/test'),
+  testConfig = require('./config/env/test'),
   fs = require('fs'),
   path = require('path');
 
@@ -184,7 +185,7 @@ module.exports = function (grunt) {
           print: 'detail',
           coverage: true,
           require: 'test.js',
-          coverageFolder: 'coverage',
+          coverageFolder: 'coverage/server',
           reportFormats: ['cobertura','lcovonly'],
           check: {
             lines: 40,
@@ -222,6 +223,8 @@ module.exports = function (grunt) {
   });
 
   grunt.event.on('coverage', function(lcovFileContents, done) {
+    // Set coverage config so karma-coverage knows to run coverage
+    testConfig.coverage = true;
     require('coveralls').handleInput(lcovFileContents, function(err) {
       if (err) {
         return done(err);
@@ -232,6 +235,7 @@ module.exports = function (grunt) {
 
   // Load NPM tasks
   require('load-grunt-tasks')(grunt);
+  grunt.loadNpmTasks('grunt-protractor-coverage');
 
   // Make sure upload directory exists
   grunt.task.registerTask('mkdir:upload', 'Task that makes sure upload directory exists.', function () {
@@ -297,11 +301,10 @@ module.exports = function (grunt) {
   // Run the project tests
   grunt.registerTask('test', ['env:test', 'lint', 'mkdir:upload', 'copy:localConfig', 'server', 'mochaTest', 'karma:unit', 'protractor']);
   grunt.registerTask('test:server', ['env:test', 'lint', 'server', 'mochaTest']);
-  grunt.registerTask('test:client', ['env:test', 'lint', 'server', 'karma:unit']);
+  grunt.registerTask('test:client', ['env:test', 'lint', 'karma:unit']);
   grunt.registerTask('test:e2e', ['env:test', 'lint', 'dropdb', 'server', 'protractor']);
-
   // Run project coverage
-  grunt.registerTask('coverage', ['env:test', 'lint', 'mocha_istanbul:coverage']);
+  grunt.registerTask('coverage', ['env:test', 'lint', 'mocha_istanbul:coverage', 'karma:unit']);
 
   // Run the project in development mode
   grunt.registerTask('default', ['env:dev', 'lint', 'mkdir:upload', 'copy:localConfig', 'concurrent:default']);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,13 @@
  */
 var _ = require('lodash'),
   defaultAssets = require('./config/assets/default'),
-  testAssets = require('./config/assets/test');
+  testAssets = require('./config/assets/test'),
+  testConfig = require('./config/env/test'),
+  karmaReporters = ['progress'];
+
+if (testConfig.coverage) {
+  karmaReporters.push('coverage');
+}
 
 // Karma configuration
 module.exports = function (karmaConfig) {
@@ -14,7 +20,14 @@ module.exports = function (karmaConfig) {
     frameworks: ['jasmine'],
 
     preprocessors: {
-      'modules/*/client/views/**/*.html': ['ng-html2js']
+      'modules/*/client/views/**/*.html': ['ng-html2js'],
+      'modules/core/client/app/config.js': ['coverage'],
+      'modules/core/client/app/init.js': ['coverage'],
+      'modules/*/client/*.js': ['coverage'],
+      'modules/*/client/config/*.js': ['coverage'],
+      'modules/*/client/controllers/*.js': ['coverage'],
+      'modules/*/client/directives/*.js': ['coverage'],
+      'modules/*/client/services/*.js': ['coverage']
     },
 
     ngHtml2JsPreprocessor: {
@@ -30,7 +43,22 @@ module.exports = function (karmaConfig) {
 
     // Test results reporter to use
     // Possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
-    reporters: ['progress'],
+    reporters: karmaReporters,
+
+    // Configure the coverage reporter
+    coverageReporter: {
+      dir : 'coverage/client',
+      reporters: [
+        // Reporters not supporting the `file` property
+        { type: 'html', subdir: 'report-html' },
+        { type: 'lcov', subdir: 'report-lcov' },
+        // Output coverage to console
+        { type: 'text' }
+      ],
+      instrumenterOptions: {
+        istanbul: { noCompact: true }
+      }
+    },
 
     // Web server port
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "grunt-ng-annotate": "^1.0.1",
     "grunt-node-inspector": "~0.3.0",
     "grunt-nodemon": "~0.4.0",
+    "grunt-protractor-coverage": "~0.2.15",
     "grunt-protractor-runner": "^2.1.0",
     "gulp": "^3.9.0",
     "gulp-angular-templatecache": "^1.7.0",


### PR DESCRIPTION
Adding karma coverage for displaying client side test coverage when running `grunt coverage`.
![karma-coverage](https://cloud.githubusercontent.com/assets/3456708/10474111/b7219fba-7200-11e5-9ef4-fcec5b5e8fee.png)
