### PR TITLE
[bug] Favicon invalid path [fixes #979]

### DIFF
--- a/modules/core/server/views/layout.server.view.html
+++ b/modules/core/server/views/layout.server.view.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -19,17 +19,17 @@
   <meta property="og:title" content="{{title}}">
   <meta property="og:description" content="{{description}}">
   <meta property="og:url" content="{{url}}">
-  <meta property="og:image" content="{{url}}{{logo}}">
+  <meta property="og:image" content="{{logo}}">
   <meta property="og:type" content="website">
 
   <!-- Twitter META -->
   <meta name="twitter:title" content="{{title}}">
   <meta name="twitter:description" content="{{description}}">
   <meta name="twitter:url" content="{{url}}">
-  <meta name="twitter:image" content="{{url}}modules/core/img/brand/logo.png">
+  <meta name="twitter:image" content="{{logo}}">
 
   <!-- Fav Icon -->
-  <link href="{{url}}{{favicon}}" rel="shortcut icon" type="image/x-icon">
+  <link href="{{favicon}}" rel="shortcut icon" type="image/x-icon">
 
   <!-- Application CSS Files -->
   {% for cssFile in cssFiles %}<link rel="stylesheet" href="{{cssFile}}">{% endfor %}
@@ -47,12 +47,12 @@
   <script type="text/javascript">
     var user = {{ user | json | safe }};
   </script>
-  
+
   <!--Load The Socket.io File-->
   <script type="text/javascript" src="/socket.io/socket.io.js"></script>
 
   <!--Application JavaScript Files-->
-  {% for jsFile in jsFiles %}<script type="text/javascript" src="{{jsFile}}"></script>{% endfor %} 
+  {% for jsFile in jsFiles %}<script type="text/javascript" src="{{jsFile}}"></script>{% endfor %}
 
   {% if livereload %}
   <!--Livereload script rendered -->


### PR DESCRIPTION
Removed `{{url}}` from the Favicon path. This fixes the intermittent issues with the path resolving to an invalid location.

This seems to fix the bug with the Favicon invalid path. However, as discussed in #979, there are still remaining questions as to why these lines are using `locals.url` and `locals.logo` with the META tags
https://github.com/meanjs/mean/blob/master/modules/core/server/views/layout.server.view.html#L17-L29

Does anyone have any insight into these, and how we should address these issues? I think it would be appropriate to address all these issues in this PR. We just need to decide on how.
