### PR TITLE
Adding configuration to fail grunt task if e2e tests fail

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -201,7 +201,6 @@ module.exports = function (grunt) {
     protractor: {
       options: {
         configFile: 'protractor.conf.js',
-        keepAlive: true,
         noColor: false,
         webdriverManagerUpdate: true
       },


### PR DESCRIPTION
fixing #961, failing grunt task will fail the travis build which is the desired behavior