### PR TITLE
Fix 404 error on Generator Repo link

### DIFF
--- a/_includes/docs/0.4.x/gettingstarted.html
+++ b/_includes/docs/0.4.x/gettingstarted.html
@@ -39,7 +39,7 @@
     There are several ways you can get the MEAN.JS boilerplate:
   </p>
   <h3>Yo Generator</h3>
-  <p>The generator is still in development. See the <a href="https://github.com/meanjs/generator-meanjs/tree/0.4-dev">Generator Repo</a> for information on how to use the development version.
+  <p>The generator is still in development. See the <a href="https://github.com/meanjs/generator-meanjs">Generator Repo</a> for information on how to use the development version.
   </p>
   <p class="alert alert-info">
     <b>Note:</b> If you want to support

--- a/generator.html
+++ b/generator.html
@@ -67,7 +67,7 @@ title: Generator
     </i>
 
     <div class="alert alert-danger" role="alert"><strong>The generator is for the 0.3.x stable release!</strong> 
-      The generator for the latest master/0.4.0 release is under development. See the <a href="https://github.com/meanjs/generator-meanjs/tree/0.4-dev">github repo</a> for more information about the 0.4.0 generator</div>
+      The generator for the latest master/0.4.0 release is under development. See the <a href="https://github.com/meanjs/generator-meanjs">github repo</a> for more information about the 0.4.0 generator</div>
 
     <div class="inner-link-anchor" id="overview"></div>
     <section class="page-header">


### PR DESCRIPTION
Fixed Generator Repo link on getting started page and 0.4.1 documentation page