### PR TITLE
Moving Travis CI webhooks config to environment variable 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ after_script:
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/249daf9851ea4776f34e
+      - $GITTER_IM_URL
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always


### PR DESCRIPTION
Closes #898   - addressing the issue where the webhook API is hard-coded into the travis config file
