### PR TITLE
[bug] Dont use Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,3 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
-cache:
-  apt: true
-  directories:
-  - node_modules/
-  - public/lib/


### PR DESCRIPTION
Having cache on the build is gibing us a false positive. As soon as I remove the cache, it will use the latest npm modules, and let us know when it's truly failing because of package dependencies.

I cloned the repo into a new directory and I'm getting the same mongo error locally as this PR is able to duplicate on the server.