### PR TITLE
[hotfix] Lock mongoose version to a working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash": "^3.10.0",
     "method-override": "^2.3.3",
     "mocha": "~1.20.0",
-    "mongoose": "^4.0.6",
+    "mongoose": "4.1.11",
     "morgan": "^1.6.1",
     "multer": "0.1.8",
     "nodemailer": "^1.4.0",


### PR DESCRIPTION
MAJOR BUG!!
(the app does not run until this is merged in)
The latest release of mongoose this morning broke changes in the repo. #1008 proves this by removing the cache in travis and forcing travis to use the latest version of mongoose. 