### PR TITLE
feat(config): Local environment configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ public/dist/
 uploads
 modules/users/client/img/profile/uploads
 config/env/local.js
+config/env/local-*.js
 *.pem
 
 # Ignoring MEAN.JS's gh-pages branch for documenation

--- a/config/config.js
+++ b/config/config.js
@@ -187,12 +187,8 @@ var initGlobalConfig = function () {
   var pkg = require(path.resolve('./package.json'));
   config.meanjs = pkg;
 
-  // We only extend the config object with the local.js custom/local environment if we are on
-  // production or development environment. If test environment is used we don't merge it with local.js
-  // to avoid running test suites on a prod/dev environment (which delete records and make modifications)
-  if (process.env.NODE_ENV !== 'test') {
-    config = _.merge(config, (fs.existsSync(path.join(process.cwd(), 'config/env/local.js')) && require(path.join(process.cwd(), 'config/env/local.js'))) || {});
-  }
+  // Extend the config object with the local-NODE_ENV.js custom/local environment. This will override any settings present in the local configuration.
+  config = _.merge(config, (fs.existsSync(path.join(process.cwd(), 'config/env/local-' + process.env.NODE_ENV + '.js')) && require(path.join(process.cwd(), 'config/env/local-' + process.env.NODE_ENV + '.js'))) || {});
 
   // Initialize global globbed files
   initGlobalConfigFiles(config, assets);

--- a/config/env/local.example.js
+++ b/config/env/local.example.js
@@ -1,10 +1,21 @@
 'use strict';
 
-// Rename this file to local.js for having a local configuration variables that
+// Rename this file to local-NODE_ENV.js (i.e. local-development.js, or local-test.js) for having a local configuration variables that
 // will not get commited and pushed to remote repositories.
 // Use it for your API keys, passwords, etc.
 
-/* For example:
+// WARNING: When using this example for multiple NODE_ENV's concurrently, make sure you update the 'db' settings appropriately.
+// You do not want to accidentally overwrite/lose any data. For instance, if you create a file for 'test' and don't change the 
+// database name in the setting below, running the tests will drop all the data from the specified database.
+//
+// You may end up with a list of files, that will be used with their corresponding NODE_ENV:
+//
+// local-development.js
+// local-test.js
+// local-production.js
+//
+
+/* For example (Development):
 
 module.exports = {
   db: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -218,9 +218,9 @@ module.exports = function (grunt) {
     copy: {
       localConfig: {
         src: 'config/env/local.example.js',
-        dest: 'config/env/local.js',
+        dest: 'config/env/local-development.js',
         filter: function () {
-          return !fs.existsSync('config/env/local.js');
+          return !fs.existsSync('config/env/local-development.js');
         }
       }
     }


### PR DESCRIPTION
**EDIT: 10/29/2015**

**This PR has changed quite a bit, and originally was not properly described. Please see the below commit, and discussion.**

Enables the setting of the test database configuration inside of the local environment config. If this setting is present, then it will override the db setting in the Test environment config. This will compliment the already existing `db` setting in local.js.

I've also added environment variables to Production, Test, and Development:
`process.env.MONGO_USER`
`process.env.MONGO_PASS`

This is both an enhancement, and support feature. Newer versions of MongoDB are deprecating MONGODB-CR authentication. Going forward it is best practice to provide the `user` & `pass` options with the mongoose `connect` method.

This also enhances the experience of a meanjs user, by providing an easy way to manage their connections between dev & test databases. For someone (like me) using MongoLab, the ability to pass the connection options to mongoose will save a lot of time during development/testing.

For me, the way I have been going about managing my testing database is by manually setting `MONGOLAB_URI` to my URI; which includes the user & pass. However, once Mongoose is upgraded  to a version that no longer supports this, I would lose the ability to connect my mean app to my Test database.

I set this PR as a WIP because I anticipate much debate about this implementation. However, I would really like to get this conversation going. We can't avoid Mongoose upgrades for too long.
