### PR TITLE
[hotfix] Logger Development config default

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -19,16 +19,16 @@ module.exports = {
     options: {
       // Stream defaults to process.stdout
       // Uncomment/comment to toggle the logging to a log on the file system
-      stream: {
-        directoryPath: process.cwd(),
-        fileName: 'access.log',
-        rotatingLogs: { // for more info on rotating logs - https://github.com/holidayextras/file-stream-rotator#usage
-          active: false, // activate to use rotating logs 
-          fileName: 'access-%DATE%.log', // if rotating logs are active, this fileName setting will be used
-          frequency: 'daily',
-          verbose: false
-        }
-      }
+      //stream: {
+      //  directoryPath: process.cwd(),
+      //  fileName: 'access.log',
+      //  rotatingLogs: { // for more info on rotating logs - https://github.com/holidayextras/file-stream-rotator#usage
+      //    active: false, // activate to use rotating logs 
+      //    fileName: 'access-%DATE%.log', // if rotating logs are active, this fileName setting will be used
+      //    frequency: 'daily',
+      //    verbose: false
+      //  }
+      //}
     }
   },
   app: {


### PR DESCRIPTION
Reverts the default Logger setting to use the stdout by default, rather than the stream option for the Development env config.

I realized this might trip some users up, since when the Logger config was implemented (https://github.com/meanjs/mean/commit/8cd2291a6a8d14cc7a75320944c532ff8b41668f)  I had overlooked the fact that users probably wouldn't want the Stream option turned on by default.
