### PR TITLE
[hotfix] SeedDB missing in env config

### DIFF
--- a/config/env/cloud-foundry.js
+++ b/config/env/cloud-foundry.js
@@ -66,5 +66,29 @@ module.exports = {
         pass: getCred('mean-mail', 'password') || 'MAILER_PASSWORD'
       }
     }
+  },
+  seedDB: {
+    seed: process.env.MONGO_SEED === 'true' ? true : false,
+    options: {
+      logResults: process.env.MONGO_SEED_LOG_RESULTS === 'false' ? false : true,
+      seedUser: {
+        username: process.env.MONGO_SEED_USER_USERNAME || 'user',
+        provider: 'local',
+        email: process.env.MONGO_SEED_USER_EMAIL || 'user@localhost.com',
+        firstName: 'User',
+        lastName: 'Local',
+        displayName: 'User Local',
+        roles: ['user']
+      },
+      seedAdmin: {
+        username: process.env.MONGO_SEED_ADMIN_USERNAME || 'admin',
+        provider: 'local',
+        email: process.env.MONGO_SEED_ADMIN_EMAIL || 'admin@localhost.com',
+        firstName: 'Admin',
+        lastName: 'Local',
+        displayName: 'Admin Local',
+        roles: ['user', 'admin']
+      }
+    }
   }
 };

--- a/config/lib/app.js
+++ b/config/lib/app.js
@@ -10,7 +10,7 @@ var config = require('../config'),
   seed = require('./seed');
 
 function seedDB() {
-  if (config.seedDB.seed) {
+  if (config.seedDB && config.seedDB.seed) {
     console.log(chalk.bold.red('Warning:  Database seeding is turned on'));
     seed.start();
   }


### PR DESCRIPTION
Adds a check for the existence of the seedDB config setting, before
attempting to read config.seedDB.seed setting.

Solves the problem when the seedDB config setting is missing from a
environment config, that causes the application to throw an exception at
startup.

As pointed out by @ryanjbaxter, due to the `seedDB` setting missing from the Cloud-Foundry env config.
