### PR TITLE
Duplicate CRUD Test - Profile Picture

### DIFF
--- a/modules/users/tests/server/user.server.routes.tests.js
+++ b/modules/users/tests/server/user.server.routes.tests.js
@@ -876,16 +876,6 @@ describe('User CRUD tests', function () {
       });
   });
 
-  it('should not be able to change profile picture if not signed in', function (done) {
-    agent.post('/api/users/picture')
-      .attach('newProfilePicture', './modules/users/client/img/profile/default.png')
-      .send(credentials)
-      .expect(400)
-      .end(function (userInfoErr, userInfoRes) {
-        done(userInfoErr);
-      });
-  });
-
   it('should not be able to change profile picture if attach a picture with a different field name', function (done) {
     agent.post('/api/auth/signin')
       .send(credentials)


### PR DESCRIPTION
Removes a duplicate User CRUD test for Profile Picture.

There are two reasons for this commit.

1) Duplicate of https://github.com/meanjs/mean/blob/master/modules/users/tests/server/user.server.routes.tests.js#L833-L848
2) This test is problematic in Windows environment.
  Related to:
  https://github.com/visionmedia/supertest/issues/230
  https://github.com/visionmedia/supertest/issues/258

The latter may be an issue with the `.attach` method not completely loading the file into memory before the 400 status response is sent back due to no User logged in.