### PR TITLE
test(travis): Add Testing for Node 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ node_js:
   - 0.10
   - 0.12
   - 4
+  - 5
 # NodeJS v4 requires gcc 4.8
 env:
   - NODE_ENV=travis CXX="g++-4.8" CC="gcc-4.8"
+matrix:
+  allow_failures:
+    - node_js: 5
 services:
   - mongodb
 # gcc 4.8 requires ubuntu-toolchain-r-test

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Before you begin we recommend you read about the basic building blocks that asse
 ## Prerequisites
 Make sure you have installed all of the following prerequisites on your development machine:
 * Node.js - [Download & Install Node.js](https://nodejs.org/en/download/) and the npm package manager. If you encounter any problems, you can also use this [GitHub Gist](https://gist.github.com/isaacs/579814) to install Node.js.
+  * Node v5 IS NOT SUPPORTED AT THIS TIME! 
 * MongoDB - [Download & Install MongoDB](http://www.mongodb.org/downloads), and make sure it's running on the default port (27017).
 * Ruby - [Download & Install Ruby](https://www.ruby-lang.org/en/documentation/installation/)
 * Bower - You're going to use the [Bower Package Manager](http://bower.io/) to manage your front-end packages. Make sure you've installed Node.js and npm first, then install bower globally using npm:


### PR DESCRIPTION
Added Node 5 to the `.travis.yml`, but allowed failures. Since Node v5 uses npm 3 there's some work to be done to support it. 

Since the build is currently failing on Node 5, I added a note to the README under the prerequisites to make clear that Node 5 is not supported at this time. 