### PR TITLE
Fix typo on Docs 0.4.1

### DIFF
--- a/_includes/docs/0.4.x/index.html
+++ b/_includes/docs/0.4.x/index.html
@@ -25,11 +25,11 @@
   </div>
   <section class="col-md-10 col-md-offset-2">
     <i class="small text-muted">
-      Last updated: 14 Jul 2015.
+      Last updated: 17 Nov 2015.
     </i>
 
     <div class="alert alert-danger" role="alert"><strong>The documentation for 0.4.1 is under development. </strong> 
-      If you discover any issues or typos in the documentation, or if you feel like practicing your technical writing, please let us know by submitting on issue on github or submitting a pull request.</div>
+      If you discover any issues or typos in the documentation, or if you feel like practicing your technical writing, please let us know by submitting an issue on github or submitting a pull request.</div>
 
     {% include docs/0.4.x/overview.html %}
 


### PR DESCRIPTION
Small typo on the 0.4.x documentation in the documentation alert div here: http://meanjs.org/docs/0.4.x/

Change "...please let us know by submitting on issue on github ..." to "...please let us know by submitting an issue on github ...". Changing first "on" to "an".