### PR TITLE
fix(users): Refresh user providerData when the user log again

### DIFF
--- a/modules/users/server/controllers/users/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users/users.authentication.server.controller.js
@@ -180,7 +180,7 @@ exports.saveOAuthUserProfile = function (req, providerUserProfile, done) {
             user.markModified('providerData');
              // And save the user
             user.save(function(err) {
-                return done(err, user);
+              return done(err, user);
             });
           } else if (user.additionalProvidersData) {
             user.additionalProvidersData[providerUserProfile.provider] = providerUserProfile.providerData;
@@ -188,7 +188,7 @@ exports.saveOAuthUserProfile = function (req, providerUserProfile, done) {
             user.markModified('additionalProvidersData');
             // Then tell mongoose that we've updated the image field
             user.save(function(err) {
-                return done(err, user);
+              return done(err, user);
             });
           } else {
             return done(err, user);

--- a/modules/users/server/controllers/users/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users/users.authentication.server.controller.js
@@ -173,7 +173,26 @@ exports.saveOAuthUserProfile = function (req, providerUserProfile, done) {
             });
           });
         } else {
-          return done(err, user);
+          // set the new data from the provider
+          if (user.providerData) {
+            user.providerData = providerUserProfile.providerData;
+            // Then tell mongoose that we've updated the providerData field
+            user.markModified('providerData');
+             // And save the user
+            user.save(function(err) {
+                return done(err, user);
+            });
+          } else if (user.additionalProvidersData) {
+            user.additionalProvidersData[providerUserProfile.provider] = providerUserProfile.providerData;
+            // Then tell mongoose that we've updated the providerData field
+            user.markModified('additionalProvidersData');
+            // Then tell mongoose that we've updated the image field
+            user.save(function(err) {
+                return done(err, user);
+            });
+          } else {
+            return done(err, user);
+          }
         }
       }
     });

--- a/modules/users/server/controllers/users/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users/users.authentication.server.controller.js
@@ -173,9 +173,11 @@ exports.saveOAuthUserProfile = function (req, providerUserProfile, done) {
             });
           });
         } else {
-          // set the new data from the provider
-          if (user.providerData) {
-            user.providerData = providerUserProfile.providerData;
+          // set the new tokens from the provider user profile
+          if (user.providerData && user.provider === providerUserProfile.provider) {
+            // Update user's provider data access and refresh tokens
+            user.providerData.accessToken = providerUserProfile.providerData.accessToken;
+            user.providerData.refreshToken = providerUserProfile.providerData.refreshToken;
             // Then tell mongoose that we've updated the providerData field
             user.markModified('providerData');
              // And save the user
@@ -183,7 +185,9 @@ exports.saveOAuthUserProfile = function (req, providerUserProfile, done) {
               return done(err, user);
             });
           } else if (user.additionalProvidersData) {
-            user.additionalProvidersData[providerUserProfile.provider] = providerUserProfile.providerData;
+            // Update user's additional provider data access and refresh tokens
+            user.additionalProvidersData[providerUserProfile.provider].accessToken = providerUserProfile.providerData.accessToken;
+            user.additionalProvidersData[providerUserProfile.provider].refreshToken = providerUserProfile.providerData.refreshToken;
             // Then tell mongoose that we've updated the providerData field
             user.markModified('additionalProvidersData');
             // Then tell mongoose that we've updated the image field


### PR DESCRIPTION
Refresh the user providers's data or the users additional providers's data
when he log again with a social account to maintin the accuracy of the data.

Fixes #511