### PR TITLE
feat(config): Gulp Server Watch for Mocha

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@
 var _ = require('lodash'),
   defaultAssets = require('./config/assets/default'),
   testAssets = require('./config/assets/test'),
+  glob = require('glob'),
   gulp = require('gulp'),
   gulpLoadPlugins = require('gulp-load-plugins'),
   runSequence = require('run-sequence'),
@@ -16,6 +17,7 @@ var _ = require('lodash'),
   }),
   path = require('path'),
   endOfLine = require('os').EOL,
+  argv = require('yargs').argv,
   protractor = require('gulp-protractor').protractor,
   webdriver_update = require('gulp-protractor').webdriver_update,
   webdriver_standalone = require('gulp-protractor').webdriver_standalone,
@@ -65,6 +67,35 @@ gulp.task('watch', function () {
   } else {
     gulp.watch(defaultAssets.server.gulpConfig, ['jshint']);
     gulp.watch(defaultAssets.client.views).on('change', plugins.livereload.changed);
+  }
+
+  if (process.env.NODE_ENV === 'test') {
+    // Add Server Test file rules
+    gulp.watch([testAssets.tests.server, defaultAssets.server.allJS], ['test:server']).on('change', function (file) {
+      var runOnlyChangedTestFile = argv.onlyChanged ? true : false;
+
+      // check if we should only run a changed test file
+      if (runOnlyChangedTestFile) {
+        var changedTestFiles = [];
+
+        // iterate through server test glob patterns
+        _.forEach(testAssets.tests.server, function (pattern) {
+          // determine if the changed (watched) file is a server test
+          _.forEach(glob.sync(pattern), function (f) {
+            var filePath = path.resolve(f);
+
+            if (filePath === path.resolve(file.path)) {
+              changedTestFiles.push(f);
+            }
+          });
+        });
+
+        // set task argument for tracking changed test files
+        argv.changedTestFiles = changedTestFiles;
+      }
+
+      plugins.livereload.changed();
+    });
   }
 });
 
@@ -181,13 +212,14 @@ gulp.task('templatecache', function () {
 gulp.task('mocha', function (done) {
   // Open mongoose connections
   var mongoose = require('./config/lib/mongoose.js');
+  var testSuites = Array.isArray(argv.changedTestFiles) && argv.changedTestFiles.length ? argv.changedTestFiles : testAssets.tests.server;
   var error;
 
   // Connect mongoose
   mongoose.connect(function () {
     mongoose.loadModels();
     // Run the tests
-    gulp.src(testAssets.tests.server)
+    gulp.src(testSuites)
       .pipe(plugins.mocha({
         reporter: 'spec',
         timeout: 10000
@@ -273,6 +305,14 @@ gulp.task('test', function (done) {
 
 gulp.task('test:server', function (done) {
   runSequence('env:test', 'lint', 'mocha', done);
+});
+
+// Watch all server files for changes & run server tests (test:server) task on changes
+// optional arguments: 
+//    --onlyChanged - optional argument for specifying that only the tests in a changed Server Test file will be run
+// example usage: gulp test:server:watch --onlyChanged
+gulp.task('test:server:watch', function (done) {
+  runSequence('test:server', 'watch', done);
 });
 
 gulp.task('test:client', function (done) {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "mock-fs": "~3.4.0",
     "run-sequence": "^1.1.1",
     "should": "^7.0.1",
-    "supertest": "^1.0.1"
+    "supertest": "^1.0.1",
+    "yargs": "~3.30.0"
   }
 }


### PR DESCRIPTION
Adds a Gulp task that watches all server files (including server tests),
and upon any changes it will perform the Gulp *test:server* task.

Also, includes an **optional** argument for the task that can specify
that if the changed file is a test, then it will only run that test
file.

Example usage: gulp test:server:watch --onlyChanged