### PR TITLE
change rvm path for bluemix deployment

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -18,7 +18,7 @@ stages:
       gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
       curl -sSL https://get.rvm.io | bash -s stable --ruby --gems=sass
       # Start RVM
-      source /home/jenkins/.rvm/scripts/rvm
+      source /home/pipeline/.rvm/scripts/rvm
       # Build MEANJS
       npm install
       grunt build


### PR DESCRIPTION
I tried to use the bluemix deploy button. There was an error with running rvm in the deployment phase.
After changing the path everything worked smoothly.