### PR TITLE
fix(core): Client routes guest access bug

### DIFF
--- a/modules/core/client/app/init.js
+++ b/modules/core/client/app/init.js
@@ -19,7 +19,7 @@ angular.module(ApplicationConfiguration.applicationModuleName).run(function ($ro
     if (toState.data && toState.data.roles && toState.data.roles.length > 0) {
       var allowed = false;
       toState.data.roles.forEach(function (role) {
-        if (Authentication.user.roles !== undefined && Authentication.user.roles.indexOf(role) !== -1) {
+        if ((role === 'guest') || (Authentication.user && Authentication.user.roles !== undefined && Authentication.user.roles.indexOf(role) !== -1)) {
           allowed = true;
           return true;
         }


### PR DESCRIPTION
Adds a check for the existence of the "guest" role in the client route
state configuration of `data.roles` in the $stateChangeStart of core
client app init configuration.

If this role is present then it doesn't attempt to check authentication
on the route that is being transitioned to.

Fixes https://github.com/meanjs/mean/issues/1098