### PR TITLE
Adding host configuration feature

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -8,6 +8,7 @@ module.exports = {
     googleAnalyticsTrackingID: process.env.GOOGLE_ANALYTICS_TRACKING_ID || 'GOOGLE_ANALYTICS_TRACKING_ID'
   },
   port: process.env.PORT || 3000,
+  host: process.env.HOST || '0.0.0.0',
   templateEngine: 'swig',
   // Session Cookie settings
   sessionCookie: {

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -7,6 +7,8 @@ module.exports = {
     certificate: './config/sslcerts/cert.pem'
   },
   port: process.env.PORT || 8443,
+  // Binding to 127.0.0.1 is safer in production.
+  host: process.env.HOST || '0.0.0.0',
   db: {
     uri: process.env.MONGOHQ_URL || process.env.MONGOLAB_URI || 'mongodb://' + (process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost') + '/mean',
     options: {

--- a/config/lib/app.js
+++ b/config/lib/app.js
@@ -37,8 +37,8 @@ module.exports.start = function start(callback) {
 
   _this.init(function (app, db, config) {
 
-    // Start the app by listening on <port>
-    app.listen(config.port, function () {
+    // Start the app by listening on <port> at <host>
+    app.listen(config.port, config.host, function () {
 
       // Logging initialization
       console.log('--');


### PR DESCRIPTION
Adding the functionality of configuring the host to start the server. 

By default set this to `127.0.0.1` as the best practice is to run the server locally and expose the port via a proxy like nginx.