### PR TITLE
fix(articles): Orphaned User reference throws server error

### DIFF
--- a/modules/articles/client/views/list-articles.client.view.html
+++ b/modules/articles/client/views/list-articles.client.view.html
@@ -8,7 +8,8 @@
         Posted on
         <span ng-bind="article.created | date:'mediumDate'"></span>
         by
-        <span ng-bind="article.user.displayName"></span>
+        <span ng-if="article.user" ng-bind="article.user.displayName"></span>
+        <span ng-if="!article.user">Deleted User</span>
       </small>
       <h4 class="list-group-item-heading" ng-bind="article.title"></h4>
       <p class="list-group-item-text" ng-bind="article.content"></p>

--- a/modules/articles/client/views/view-article.client.view.html
+++ b/modules/articles/client/views/view-article.client.view.html
@@ -15,7 +15,8 @@
       Posted on
       <span ng-bind="article.created | date:'mediumDate'"></span>
       by
-      <span ng-bind="article.user.displayName"></span>
+      <span ng-if="article.user" ng-bind="article.user.displayName"></span>
+      <span ng-if="!article.user">Deleted User</span>
     </em>
   </small>
   <p class="lead" ng-bind="article.content"></p>

--- a/modules/articles/server/policies/articles.server.policy.js
+++ b/modules/articles/server/policies/articles.server.policy.js
@@ -49,7 +49,7 @@ exports.isAllowed = function (req, res, next) {
   var roles = (req.user) ? req.user.roles : ['guest'];
 
   // If an article is being processed and the current user created it then allow any manipulation
-  if (req.article && req.user && req.article.user.id === req.user.id) {
+  if (req.article && req.user && req.article.user && req.article.user.id === req.user.id) {
     return next();
   }
 


### PR DESCRIPTION
Adds an additional check for the existence of a populated user reference, when determining if the current user has immediate access to the requested article.

Without this fix, the server will throw an error if the requested article doesn't have a populated user field.

Modified the article & articles list view's to check if the article has a populated user. If not, then it will display "Deleted User" in place of the missing user reference.

Fixes #1082
