### PR TITLE
fix(users): ProfileImageURL sanitize with ngSanitize

### DIFF
--- a/modules/core/server/controllers/core.server.controller.js
+++ b/modules/core/server/controllers/core.server.controller.js
@@ -15,7 +15,7 @@ exports.renderIndex = function (req, res) {
       username: validator.escape(req.user.username),
       created: req.user.created.toString(),
       roles: req.user.roles,
-      profileImageURL: validator.escape(req.user.profileImageURL),
+      profileImageURL: req.user.profileImageURL,
       email: validator.escape(req.user.email),
       lastName: validator.escape(req.user.lastName),
       firstName: validator.escape(req.user.firstName)


### PR DESCRIPTION
~~Adds angular-sanitize to the project, and uses it to sanitize the
profileImageURL field of the Authentication.user object.~~

Based on the conversation in #1127, I've decided to revert the original changes in this PR & merely remove the `validator.escape` call on the `profileImageUrl` field. We don't need to worry about vulnerabilities on this field.

Fixes https://github.com/meanjs/mean/issues/1127
