### PR TITLE
fix(documentation): Contributing.md typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Fixes #82
   * The scope should be where the change took place.
   * Examples: users, core, config, articles
 * Subject:
-  * The subject line should be clear and consice as to what is being accomplished in the commit.
+  * The subject line should be clear and concise as to what is being accomplished in the commit.
 * General Rules:
   * No Line in the Commit message can be longer than 80 characters.
 * Refrence: [Angular Conventions](https://github.com/ajoslin/conventional-changelog/blob/master/conventions/angular.md)


### PR DESCRIPTION
Fixes 'consice' typo to 'concise' in CONTRIBUTING.md
Was originally in #1135, now moved to separate PR.

Fixes #1136