### PR TITLE
fix(build): Linting error at gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -196,7 +196,7 @@ gulp.task('imagemin', function () {
   return gulp.src(defaultAssets.client.img)
     .pipe(plugins.imagemin({
       progressive: true,
-      svgoPlugins: [{removeViewBox: false}],
+      svgoPlugins: [{ removeViewBox: false }],
       use: [pngquant()]
     }))
     .pipe(gulp.dest('public/dist/img'));


### PR DESCRIPTION
Fixes an error occurring when running `gulp`:
```bash
/mean/gulpfile.js
  199:22  error  A space is required after '{'   object-curly-spacing
  199:42  error  A space is required before '}'  object-curly-spacing
```