### PR TITLE
fix(users): User email to accept null regardless of unique

### DIFF
--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -47,6 +47,7 @@ var UserSchema = new Schema({
   email: {
     type: String,
     unique: true,
+    sparse: true,
     lowercase: true,
     trim: true,
     default: '',


### PR DESCRIPTION
Provider Twitter (refer `twitter.js` file) is not producing an email address on callback. When two different users signs up using twitter the second user will not be able to sign up if the first user didn't set the email address manually. 

This is due to the error of email already exist, in actual terms this is the `null` value which is conflicting the unique constraint.