### PR TITLE
fix(gulp): Fixing/updating templatecache gulp task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -204,18 +204,13 @@ gulp.task('imagemin', function () {
 
 // Angular template cache task
 gulp.task('templatecache', function () {
-  var re = new RegExp('\\' + path.sep + 'client\\' + path.sep, 'g');
-
   return gulp.src(defaultAssets.client.views)
     .pipe(plugins.templateCache('templates.js', {
       root: 'modules/',
       module: 'core',
       templateHeader: '(function () {' + endOfLine + '	\'use strict\';' + endOfLine + endOfLine + '	angular' + endOfLine + '		.module(\'<%= module %>\'<%= standalone %>)' + endOfLine + '		.run(templates);' + endOfLine + endOfLine + '	templates.$inject = [\'$templateCache\'];' + endOfLine + endOfLine + '	function templates($templateCache) {' + endOfLine,
       templateBody: '		$templateCache.put(\'<%= url %>\', \'<%= contents %>\');',
-      templateFooter: '	}' + endOfLine + '})();' + endOfLine,
-      transformUrl: function (url) {
-        return url.replace(re, path.sep);
-      }
+      templateFooter: '	}' + endOfLine + '})();' + endOfLine
     }))
     .pipe(gulp.dest('build'));
 });


### PR DESCRIPTION
The transformUrl replace function has been removed from templatecache gulp task.

The client view routes include the string "/client" in the url from mean.js 0.4.2 and the browser view request is not matching with the angular template cache url, so all the templates cache is being ignored at startup.

The task has been updated.