### PR TITLE
fix(users): Update assertion for duplicate username/email for newer v…

### DIFF
--- a/modules/users/tests/server/user.server.routes.tests.js
+++ b/modules/users/tests/server/user.server.routes.tests.js
@@ -742,7 +742,7 @@ describe('User CRUD tests', function () {
               }
 
               // Call the assertion callback
-              userInfoRes.body.message.should.equal('Username already exists');
+              userInfoRes.body.message.toLowerCase().should.containEql('username already exists');
 
               return done();
             });
@@ -794,7 +794,7 @@ describe('User CRUD tests', function () {
               }
 
               // Call the assertion callback
-              userInfoRes.body.message.should.equal('Email already exists');
+              userInfoRes.body.message.toLowerCase().should.containEql('email already exists');
 
               return done();
             });


### PR DESCRIPTION
Update assertion for duplicate username/email for newer versions of mongodb.

When running a newer version of mongodb, users are reporting an issue when executing tests because the response from the mongo request has changed.  This change should support new/old versions of the test.

Resolves #1124