### PR TITLE
feat(deps): update socket.io dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "passport-twitter": "~1.0.4",
     "phantomjs": "~1.9.19",
     "serve-favicon": "~2.3.0",
-    "socket.io": "~1.3.7",
+    "socket.io": "~1.4.5",
     "swig": "~1.4.2",
     "validator": "~4.8.0"
   },


### PR DESCRIPTION
version 1.3.7 installed with the package.json file is 6 releases behind - 1 feature release, and 5 patches. security advisors have been published for older socket.io version