### PR TITLE
fix(config): Use newer protractor

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "karma-phantomjs-launcher": "~1.0.0",
     "load-grunt-tasks": "~3.2.0",
     "mock-fs": "~3.7.0",
+    "protractor": "~3.1.1",
     "run-sequence": "~1.1.5",
     "should": "~8.2.2",
     "supertest": "~1.2.0",


### PR DESCRIPTION
Fixes issue with 2.47 of selenium webdriver
reference angular/protractor#2638
> [launcher] Process exited with error code 1
> /mean/node_modules/selenium-webdriver/lib/goog/async/nexttick.js:41
>   goog.global.setTimeout(function() { throw exception; }, 0);
>                                       ^
> 
> Error: Server terminated early with status 1
>     at Error (native)
>     at /mean/node_modules/selenium-webdriver/remote/index.js:204:18
>     at promise.ControlFlow.runInFrame_ (/mean/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:1857:20)
>     at goog.defineClass.notify (/mean/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:2448:25)
>     at promise.Promise.notify_ (/mean/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:564:12)
>     at Array.forEach (native)
>     at promise.Promise.notifyAll_ (/mean/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:553:15)
>     at goog.async.run.processWorkQueue (/mean/node_modules/selenium-webdriver/lib/goog/async/run.js:130:15)
>     at process._tickCallback (node.js:406:9)
> E2E Tests failed

Fixes #1247