### PR TITLE
fix(gulp): replacing gulp-cssmin which has been deprecated and un-maintained with gulp-csso

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -177,7 +177,7 @@ gulp.task('uglify', function () {
 // CSS minifying task
 gulp.task('cssmin', function () {
   return gulp.src(defaultAssets.client.css)
-    .pipe(plugins.cssmin())
+    .pipe(plugins.csso())
     .pipe(plugins.concat('application.min.css'))
     .pipe(gulp.dest('public/dist'));
 });

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "gulp-autoprefixer": "~3.1.0",
     "gulp-concat": "~2.6.0",
     "gulp-csslint": "~0.2.0",
-    "gulp-cssmin": "~0.1.7",
+    "gulp-csso": "~1.1.0",
     "gulp-eslint": "~2.0.0",
     "gulp-imagemin": "~2.4.0",
     "gulp-jshint": "~2.0.0",


### PR DESCRIPTION
Fixes #1251 - see the issue for motivation and other details