### PR TITLE
fix(dependency): Mongoose 4.4.7 bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "method-override": "~2.3.5",
     "gulp-wiredep": "~0.0.0",
     "mocha": "~2.4.5",
-    "mongoose": "~4.4.3",
+    "mongoose": "~4.4.3 <4.4.7",
     "morgan": "~1.6.1",
     "multer": "~1.1.0",
     "nodemailer": "~2.1.0",


### PR DESCRIPTION
Fixes an issue with Mongoose `4.4.7` that causes the database connection.db property to be  undefined. This issue is causing our builds to fail.

Sets the Mongoose version to `~4.4.3 <4.4.7` for now until we investigate further. This should solve the issue of our failing builds, when the `dropdb` Grunt/Gulp task is ran with the E2E tests.

For more context:
this line https://github.com/meanjs/mean/blob/master/gruntfile.js#L277 was throwing an exception during our builds, since the `dropdb` task is run with the E2E tests. This seemed to cause the Protractor tasks to time-out. However, there was no indication of this exception being thrown from our `dropdb` task when running with `grunt test` or in the Travis builds. I had to explicitly run `grunt test:e2e` to see this exception that led me to this fix.
