### PR TITLE
Changes Node Version In Bluemix Pipeline

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -13,6 +13,8 @@ stages:
     build_type: grunt
     script: |-
       #!/bin/bash
+      # Set Node version to 0.12
+      export PATH=/opt/IBM/node-v0.12/bin:$PATH
       # Install RVM, Ruby, and SASS
       # Needed when running grunt build
       gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "method-override": "~2.3.5",
     "gulp-wiredep": "~0.0.0",
     "mocha": "~2.4.5",
-    "mongoose": "~4.4.3",
+    "mongoose": "~4.4.3 <4.4.7",
     "morgan": "~1.6.1",
     "multer": "~1.1.0",
     "nodemailer": "~2.1.0",


### PR DESCRIPTION
fix(bluemix): Changes Node Version In Bluemix Pipeline

Fixes the requirement that MEANJS requires Node.js 0.12 in order to build.

Fixes #1138