### PR TITLE
fix(dependency): Bump Mongoose to 4.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "method-override": "~2.3.5",
     "gulp-wiredep": "~0.0.0",
     "mocha": "~2.4.5",
-    "mongoose": "~4.4.3 <4.4.7",
+    "mongoose": "~4.4.8",
     "morgan": "~1.6.1",
     "multer": "~1.1.0",
     "nodemailer": "~2.1.0",


### PR DESCRIPTION
Upgrades the Mongoose version to 4.4.8.

The need to limit Mongoose version to be less than 4.4.7 is no longer necessary due to a bug fix released with 4.4.8.

See ref: https://github.com/Automattic/mongoose/issues/3972

Resolves the need for #1264