### PR TITLE
fix(users) Fix bug file mime-type validate does not work 

### DIFF
--- a/modules/users/server/controllers/users/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users/users.profile.server.controller.js
@@ -55,11 +55,9 @@ exports.update = function (req, res) {
  */
 exports.changeProfilePicture = function (req, res) {
   var user = req.user;
-  var upload = multer(config.uploads.profileUpload).single('newProfilePicture');
-  var profileUploadFileFilter = require(path.resolve('./config/lib/multer')).profileUploadFileFilter;
-
-  // Filtering to upload only images
-  upload.fileFilter = profileUploadFileFilter;
+  var multerConfig = config.uploads.profileUpload;
+  multerConfig.fileFilter = require(path.resolve('./config/lib/multer')).profileUploadFileFilter; // Filtering to upload only images
+  var upload = multer(multerConfig).single('newProfilePicture');
 
   if (user) {
     upload(req, res, function (uploadError) {


### PR DESCRIPTION
Bad use of file type valiator for multer.fileFilter
I have been trying some more things and indeed it uploads a text file if you rename it to jpg. So it validates only the extension on the client and not the mime-type in the multer on the server. After applying the suggested change at least config/env/multer.js is called, but it is still not filtering correctly for me: all files appear to be image/jpeg when I add   console.log(file.mimetype); on line 4.

Fixes #1270 
