### PR TITLE
fix(user-Model): social signup email fix

### DIFF
--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -47,9 +47,10 @@ var UserSchema = new Schema({
   email: {
     type: String,
     unique: true,
+    sparse: true,
     lowercase: true,
     trim: true,
-    default: '',
+    //default: '',
     validate: [validateLocalStrategyEmail, 'Please fill a valid email address']
   },
   username: {

--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -50,7 +50,6 @@ var UserSchema = new Schema({
     sparse: true,
     lowercase: true,
     trim: true,
-    //default: '',
     validate: [validateLocalStrategyEmail, 'Please fill a valid email address']
   },
   username: {


### PR DESCRIPTION
fix(model): Fixed email portion of user schema

- Emails are flagged unique with a default of the empty string ''.
- However, Social signups, particularly Twitter, do not guarantee email
- If social signup results in an empty string, then the empty string is indexed as unique
- Furthermore, subsequent signups [without an email] will throw Mongo error 11000.
- This is due to the empty string now being indexed by mongo
- Fix: add 'sparse' and remove 'default' in the schema 
- Result: empty string is no longer indexed for the email field
- Social signups can now resolve successfully without providing an email