### PR TITLE
feat(gulp): test:server:watch task onlyChanged

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "node-inspector": "~0.12.7",
     "run-sequence": "~1.1.5",
     "should": "~8.2.2",
-    "supertest": "~1.2.0",
-    "yargs": "~3.32.0"
+    "supertest": "~1.2.0"
   }
 }


### PR DESCRIPTION
The test:server:watch Gulp task has a parameter `onlyChanged` that is used to specify that if a server test file was modified, then only run that test suite. This removes the parameter, and sets the task behavior to the aforementioned.

Closes #1297
