### PR TITLE
feat(core): Use ngStrictDi in production

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -25,6 +25,7 @@ var config = require('../config'),
  */
 module.exports.initLocalVariables = function (app) {
   // Setting application local variables
+  app.locals.env = process.env.NODE_ENV;
   app.locals.title = config.app.title;
   app.locals.description = config.app.description;
   if (config.secure && config.secure.ssl === true) {

--- a/modules/core/server/views/layout.server.view.html
+++ b/modules/core/server/views/layout.server.view.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html>
-<html lang="en">
+<html lang="en" {% if env === "production" %}ng-strict-di{% endif %}>
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">


### PR DESCRIPTION
Slightly changed layout template to use Angular's Strict
Dependency Injection if the app is running in production.

Fixes part of meanjs/mean#1294