### PR TITLE
fix(hsts): removing HSTS configuration set on lusca's csrf settings

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -34,11 +34,6 @@ module.exports = {
     csp: { /* Content Security Policy object */},
     xframe: 'SAMEORIGIN',
     p3p: 'ABCDEF',
-    hsts: {
-      maxAge: 31536000, // Forces HTTPS for one year
-      includeSubDomains: true,
-      preload: true
-    },
     xssProtection: true
   },
   logo: 'modules/core/client/img/brand/logo.png',


### PR DESCRIPTION
Removing HSTSconfiguration set on lusca's csrf settings ut is already configured and provided using helmet

Fixes #1308 

