### PR TITLE
fix(model paths): Default asset paths for models is incorrect

### DIFF
--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -51,7 +51,7 @@ module.exports = {
     gruntConfig: ['gruntfile.js'],
     gulpConfig: ['gulpfile.js'],
     allJS: ['server.js', 'config/**/*.js', 'modules/*/server/**/*.js'],
-    models: 'modules/*/server/models/**/*.js',
+    models: 'modules/*/server/models/*.js',
     routes: ['modules/!(core)/server/routes/**/*.js', 'modules/core/server/routes/**/*.js'],
     sockets: 'modules/*/server/sockets/**/*.js',
     config: ['modules/*/server/config/*.js'],


### PR DESCRIPTION
Models currently work because of the catch-all AllJS path one line above
my change.

We can't rely on these two lines staying the same indefinitely,
therefore I've updated the path to maintain it's integrity and
to reflect the convention currently in use.