### PR TITLE
fix(models, routes, and sockets): incorrect default asset paths

### DIFF
--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -51,9 +51,9 @@ module.exports = {
     gruntConfig: ['gruntfile.js'],
     gulpConfig: ['gulpfile.js'],
     allJS: ['server.js', 'config/**/*.js', 'modules/*/server/**/*.js'],
-    models: 'modules/*/server/models/**/*.js',
-    routes: ['modules/!(core)/server/routes/**/*.js', 'modules/core/server/routes/**/*.js'],
-    sockets: 'modules/*/server/sockets/**/*.js',
+    models: 'modules/*/server/models/*.js',
+    routes: ['modules/!(core)/server/routes/*.js', 'modules/core/server/routes/*.js'],
+    sockets: 'modules/*/server/sockets/*.js',
     config: ['modules/*/server/config/*.js'],
     policies: 'modules/*/server/policies/*.js',
     views: ['modules/*/server/views/*.html']


### PR DESCRIPTION
Models, routes and sockets currently work because of the 
catch-all AllJS path in the same file above my changes. We
can't rely on this to be true indefinitely, therefore I've 
updated the paths to maintain their integrity and to reflect the
convention currently in use.