### PR TITLE
fix(redirect url): on login from social

### DIFF
--- a/modules/users/server/controllers/users/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users/users.authentication.server.controller.js
@@ -116,7 +116,7 @@ exports.oauthCallback = function (strategy) {
           return res.redirect('/authentication/signin');
         }
 
-        return res.redirect(redirectURL || sessionRedirectURL || '/');
+        return res.redirect(sessionRedirectURL || '/');
       });
     })(req, res, next);
   };


### PR DESCRIPTION
Issue originally noted in Twitter by @jorgeram
Builds on workaround presented by @ChrisMaher

Logging in with social is broken for some, the redirectURL did not appear to be used and was causing an error as it wasn't the type the redirect function was expecting.

Fixes #1284, 