### PR TITLE
doc(getting started): Add missing word

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ git clone https://github.com/meanjs/mean.git meanjs
 This will clone the latest version of the MEAN.JS repository to a **meanjs** folder.
 
 ### Downloading The Repository Zip File
-Another way to use the MEAN.JS boilerplate is to download a zip copy from the [master branch on GitHub](https://github.com/meanjs/mean/archive/master.zip). You can also do this using `wget` command:
+Another way to use the MEAN.JS boilerplate is to download a zip copy from the [master branch on GitHub](https://github.com/meanjs/mean/archive/master.zip). You can also do this using the `wget` command:
 
 ```bash
 $ wget https://github.com/meanjs/mean/archive/master.zip -O meanjs.zip; unzip meanjs.zip; rm meanjs.zip


### PR DESCRIPTION
I think the author meant to write "using *the* `wget` command," instead of 
"using `wget` command."