### PR TITLE
fix(core): Typo in page-title.client.directives.js

### DIFF
--- a/modules/core/client/directives/page-title.client.directives.js
+++ b/modules/core/client/directives/page-title.client.directives.js
@@ -8,7 +8,7 @@
 
   function pageTitle($rootScope, $timeout, $interpolate, $state) {
     var directive = {
-      retrict: 'A',
+      restrict: 'A',
       link: link
     };
 


### PR DESCRIPTION
fix typo in modules/core/client/directives/page-title.client.directives.js

Fixes #1332