### PR TITLE
Fix(config): Use single pattern for routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,11 @@ _site/
 logs/
 build/
 
+# Emacs editor
+# ============
+*~
+.dir-locals.el
+
 # Sublime editor
 # ==============
 .sublime-project

--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -52,7 +52,7 @@ module.exports = {
     gulpConfig: ['gulpfile.js'],
     allJS: ['server.js', 'config/**/*.js', 'modules/*/server/**/*.js'],
     models: 'modules/*/server/models/**/*.js',
-    routes: ['modules/!(core)/server/routes/**/*.js', 'modules/core/server/routes/**/*.js'],
+    routes: 'modules/*/server/routes/**/*.js',
     sockets: 'modules/*/server/sockets/**/*.js',
     config: ['modules/*/server/config/*.js'],
     policies: 'modules/*/server/policies/*.js',


### PR DESCRIPTION
Use single pattern for routes in `config/assets/default.js` 

`'modules/*/server/routes/**/*.js'` instead of 
`['modules/!(core)/server/routes/**/*.js', 'modules/core/server/routes/**/*.js']`