### PR TITLE
Documentation fix for Pivotal Web Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ for hosting applications in the cloud.  After you have an account follow the bel
   *  If you are using Pivotal Web Services run `$ cf login -a api.run.pivotal.io`.
   *  If you are using IBM Bluemix run `$ cf login -a api.ng.bluemix.net`.
 * Create a Mongo DB service.
-+  *  If you are using Pivotal Web Services run `$ cf create-service mongolab sandbox mean-mongo`
++  *  If you are using Pivotal Web Services run `$ cf create-service mlab sandbox mean-mongo`
 +  *  If you are using IBM Bluemix run `$ cf create-service mongodb 100 mean-mongo`
 * Clone the GitHub repo for MEANJS if you have not already done so
   * `$ git clone https://github.com/meanjs/mean.git && cd mean`


### PR DESCRIPTION
From [issue #1364](https://github.com/meanjs/mean/issues/1364)

The company renamed itself to mLabs, and the module name changed with it.