### PR TITLE
Enhancement: Deprecating Grunt in favor of Gulp and NPM commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ Make sure you have installed all of the following prerequisites on your developm
 $ npm install -g bower
 ```
 
-* Grunt - You're going to use the [Grunt Task Runner](http://gruntjs.com/) to automate your development process. Make sure you've installed Node.js and npm first, then install grunt globally using npm:
-
-```bash
-$ npm install -g grunt-cli
-```
-
-* Gulp - (Optional) You may use Gulp for Live Reload, Linting, and SASS or LESS.
+* Gulp - Gulp is used to build the project and automate project tasks.
 
 ```bash
 $ npm install gulp -g
+```
+
+* Grunt - (Optional) You're going to use the [Grunt Task Runner](http://gruntjs.com/) to automate your development process.
+
+```bash
+$ npm install -g grunt-cli
 ```
 
 ## Downloading MEAN.JS
@@ -79,10 +79,14 @@ This command does a few things:
 * Finally, when the install process is over, npm will initiate a bower install command to install all the front-end modules needed for the application
 
 ## Running Your Application
-After the install process is over, you'll be able to run your application using Grunt, just run grunt default task:
 
-```
-$ grunt
+The MEAN.JS project integrates both Grunt and Gulp as build tools and task automation, but Grunt will be deprecated in favor of Gulp.
+While you are free to use both of them directly, we have wrapped Gulp tasks with npm scripts so that regardless of the build tool running the project is transparent to you.
+
+Run your application using npm:
+
+```bash
+$ npm start
 ```
 
 Your application should run on port 3000 with the *development* environment configuration, so in your browser just go to [http://localhost:3000](http://localhost:3000)
@@ -91,12 +95,13 @@ That's it! Your application should be running. To proceed with your development,
 If you encounter any problems, try the Troubleshooting section.
 
 * explore `config/env/development.js` for development environment configuration options
+* it is possible to
 
 ### Running in Production mode
 To run your application with *production* environment configuration, execute grunt as follows:
 
 ```bash
-$ grunt prod
+$ npm start:prod
 ```
 
 * explore `config/env/production.js` for production environment configuration options
@@ -106,13 +111,13 @@ To have default account(s) seeded at runtime:
 
 In Development:
 ```bash
-MONGO_SEED=true grunt
+MONGO_SEED=true npm start
 ```
 It will try to seed the users 'user' and 'admin'. If one of the user already exists, it will display an error message on the console. Just grab the passwords from the console.
 
 In Production:
 ```bash
-MONGO_SEED=true grunt prod
+MONGO_SEED=true npm start:prod
 ```
 This will seed the admin user one time if the user does not already exist. You have to copy the password from the console and save it.
 
@@ -127,7 +132,7 @@ $ sh ./scripts/generate-ssl-certs.sh
 Windows users can follow instructions found [here](http://www.websense.com/support/article/kbarticle/How-to-use-OpenSSL-and-Microsoft-Certification-Authority).
 After you've generated the key and certificate, place them in the *config/sslcerts* folder.
 
-Finally, execute grunt's prod task `grunt prod`
+Finally, execute grunt's prod task `npm start:prod`
 * enable/disable SSL mode in production environment change the `secure` option in `config/env/production.js`
 
 
@@ -135,44 +140,37 @@ Finally, execute grunt's prod task `grunt prod`
 You can run the full test suite included with MEAN.JS with the test task:
 
 ```bash
-$ grunt test
+$ npm test
 ```
-
-This will run both the server-side tests (located in the app/tests/ directory) and the client-side tests (located in the public/modules/*/tests/).
+This will run both the server-side tests (located in the `app/tests/` directory) and the client-side tests (located in the `public/modules/*/tests/`).
 
 To execute only the server tests, run the test:server task:
 
 ```bash
-$ grunt test:server
+$ npm test:server
 ```
 
 And to run only the client tests, run the test:client task:
 
 ```bash
-$ grunt test:client
+$ npm test:client
 ```
 
-## Running your application with Gulp
+## Running your application with Grunt
 
 After the install process, you can easily run your project with:
 
 ```bash
-$ gulp
+$ grunt
 ```
-or
-
-```bash
-$ gulp default
-```
-
 The server is now running on http://localhost:3000 if you are using the default settings.
 
-### Running Gulp Development Environment
+### Running your application with Gulp
 
 Start the development environment with:
 
 ```bash
-$ gulp dev
+$ gulp
 ```
 
 ### Running in Production mode
@@ -180,29 +178,6 @@ To run your application with *production* environment configuration, execute gul
 
 ```bash
 $ gulp prod
-```
-
-### Testing Your Application with Gulp
-Using the full test suite included with MEAN.JS with the test task:
-
-### Run all tests
-```bash
-$ gulp test
-```
-
-### Run server tests
-```bash
-gulp test:server
-```
-
-### Run client tests
-```bash
-gulp test:client
-```
-
-### Run e2e tests
-```bash
-gulp test:e2e
 ```
 
 ## Development and deployment With Docker

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ That's it! Your application should be running. To proceed with your development,
 If you encounter any problems, try the Troubleshooting section.
 
 * explore `config/env/development.js` for development environment configuration options
-* it is possible to
+* it is possible to run any gulp tasks using npm's run command, for example: `npm run gulp test:server:watch`
 
 ### Running in Production mode
 To run your application with *production* environment configuration, execute grunt as follows:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "start": "gulp",
     "start:prod": "gulp prod",
     "start:debug": "gulp debug",
+    "gulp": "gulp",
     "lint": "gulp lint",
     "test": "gulp test",
     "test:server": "gulp test:server",


### PR DESCRIPTION
feat(gulp): updating the README.md instructions with the changes to gulp being the mainstream vs the deprecation of grunt. Also added gulp as a task runner for freely executing tasks through running `npm` commands

Follow-up for #1296 