### PR TITLE
Refactoring for express-session deprecated options

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -24,8 +24,8 @@ module.exports = {
   },
   // sessionSecret should be changed for security measures and concerns
   sessionSecret: process.env.SESSION_SECRET || 'MEAN',
-  // sessionKey is set to the generic sessionId key used by PHP applications
-  // for obsecurity reasons
+  // sessionKey is the session name and is set to the generic sessionId key
+  // used by PHP applications for obsecurity reasons
   sessionKey: 'sessionId',
   sessionCollection: 'sessions',
   // Lusca config

--- a/config/env/default.js
+++ b/config/env/default.js
@@ -24,8 +24,7 @@ module.exports = {
   },
   // sessionSecret should be changed for security measures and concerns
   sessionSecret: process.env.SESSION_SECRET || 'MEAN',
-  // sessionKey is the session name and is set to the generic sessionId key
-  // used by PHP applications for obsecurity reasons
+  // sessionKey is the cookie session name
   sessionKey: 'sessionId',
   sessionCollection: 'sessions',
   // Lusca config

--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -120,7 +120,7 @@ module.exports.initSession = function (app, db) {
       httpOnly: config.sessionCookie.httpOnly,
       secure: config.sessionCookie.secure && config.secure.ssl
     },
-    key: config.sessionKey,
+    name: config.sessionKey,
     store: new MongoStore({
       mongooseConnection: db.connection,
       collection: config.sessionCollection


### PR DESCRIPTION
Updating express session name variable from `key` which is deprecated to the new variable name `name`