### PR TITLE
feat(forever): removing forever dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 RUN sudo apt-get install -yq nodejs
 
 # Install MEAN.JS Prerequisites
-RUN npm install --quiet -g grunt-cli gulp bower yo mocha karma-cli pm2 forever
+RUN npm install --quiet -g grunt-cli gulp bower yo mocha karma-cli pm2
 
 RUN mkdir /opt/mean.js
 RUN mkdir -p /opt/mean.js/public/lib

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./node_modules/.bin/forever -m 5 server.js
+web: npm start

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "express": "~4.14.0",
     "express-session": "~1.13.0",
     "file-stream-rotator": "~0.0.6",
-    "forever": "~0.15.1",
     "generate-password": "~1.1.1",
     "glob": "~7.0.0",
     "grunt": "~1.0.1",


### PR DESCRIPTION
cleaning up project dependencies by removing the forever package which is only really used by Heroku's
procfile to start up the node service