### PR TITLE
fix(wiredep): directly wire html source [WIP]

### DIFF
--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -1,31 +1,7 @@
 'use strict';
 
-/* eslint comma-dangle:[0, "only-multiline"] */
-
 module.exports = {
   client: {
-    lib: {
-      css: [
-        // bower:css
-        'public/lib/bootstrap/dist/css/bootstrap.css',
-        'public/lib/bootstrap/dist/css/bootstrap-theme.css',
-        // endbower
-      ],
-      js: [
-        // bower:js
-        'public/lib/angular/angular.js',
-        'public/lib/angular-animate/angular-animate.js',
-        'public/lib/angular-bootstrap/ui-bootstrap-tpls.js',
-        'public/lib/angular-file-upload/dist/angular-file-upload.min.js',
-        'public/lib/angular-messages/angular-messages.js',
-        'public/lib/angular-mocks/angular-mocks.js',
-        'public/lib/angular-resource/angular-resource.js',
-        'public/lib/angular-ui-router/release/angular-ui-router.js',
-        'public/lib/owasp-password-strength-test/owasp-password-strength-test.js',
-        // endbower
-      ],
-      tests: ['public/lib/angular-mocks/angular-mocks.js']
-    },
     css: [
       'modules/*/client/css/*.css'
     ],

--- a/config/assets/production.js
+++ b/config/assets/production.js
@@ -1,30 +1,7 @@
 'use strict';
 
-/* eslint comma-dangle:[0, "only-multiline"] */
-
 module.exports = {
   client: {
-    lib: {
-      css: [
-        // bower:css
-        'public/lib/bootstrap/dist/css/bootstrap.min.css',
-        'public/lib/bootstrap/dist/css/bootstrap-theme.min.css',
-        // endbower
-      ],
-      js: [
-        // bower:js
-        'public/lib/angular/angular.min.js',
-        'public/lib/angular-animate/angular-animate.min.js',
-        'public/lib/angular-bootstrap/ui-bootstrap-tpls.min.js',
-        'public/lib/angular-file-upload/dist/angular-file-upload.min.js',
-        'public/lib/angular-messages/angular-messages.min.js',
-        'public/lib/angular-mocks/angular-mocks.js',
-        'public/lib/angular-resource/angular-resource.min.js',
-        'public/lib/angular-ui-router/release/angular-ui-router.min.js',
-        'public/lib/owasp-password-strength-test/owasp-password-strength-test.js',
-        // endbower
-      ]
-    },
     css: 'public/dist/application.min.css',
     js: 'public/dist/application.min.js'
   }

--- a/config/config.js
+++ b/config/config.js
@@ -151,10 +151,10 @@ var initGlobalConfigFiles = function (config, assets) {
   config.files.server.policies = getGlobbedPaths(assets.server.policies);
 
   // Setting Globbed js files
-  config.files.client.js = getGlobbedPaths(assets.client.lib.js, 'public/').concat(getGlobbedPaths(assets.client.js, ['public/']));
+  config.files.client.js = getGlobbedPaths(assets.client.js, ['public/']);
 
   // Setting Globbed css files
-  config.files.client.css = getGlobbedPaths(assets.client.lib.css, 'public/').concat(getGlobbedPaths(assets.client.css, ['public/']));
+  config.files.client.css = getGlobbedPaths(assets.client.css, ['public/']);
 
   // Setting Globbed test files
   config.files.client.tests = getGlobbedPaths(assets.client.tests);

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -306,7 +306,6 @@ module.exports = function (grunt) {
     // Get the callback
     var done = this.async();
 
-    var path = require('path');
     var app = require(path.resolve('./config/lib/app'));
     var server = app.start(function () {
       done();

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -76,27 +76,33 @@ module.exports = function (grunt) {
       }
     },
     wiredep: {
-      fileTypes: {
-        src: 'config/assets/default.js',
-        ignorePath: '../../',
-        js: {
-          replace: {
-            css: function (filePath) {
-              var minFilePath = filePath.replace('.css', '.min.css');
-              var fullPath = path.join(process.cwd(), minFilePath);
-              if (!fs.existsSync(fullPath)) {
-                return '\'' + filePath + '\',';
-              } else {
-                return '\'' + minFilePath + '\',';
-              }
-            },
-            js: function (filePath) {
-              var minFilePath = filePath.replace('.js', '.min.js');
-              var fullPath = path.join(process.cwd(), minFilePath);
-              if (!fs.existsSync(fullPath)) {
-                return '\'' + filePath + '\',';
-              } else {
-                return '\'' + minFilePath + '\',';
+      dev: {
+        src: 'modules/core/server/views/layout.server.view.html',
+        ignorePath: /.*public\//
+      },
+      production: {
+        src: 'modules/core/server/views/layout.server.view.html',
+        ignorePath: /.*public\//,
+        fileTypes: {
+          html: {
+            replace: {
+              css: function (filePath) {
+                var minFilePath = filePath.replace('.css', '.min.css');
+                var fullPath = path.join(process.cwd(), 'public', minFilePath);
+                if (!fs.existsSync(fullPath)) {
+                  return '<link rel="stylesheet" href="' + filePath + '">';
+                } else {
+                  return '<link rel="stylesheet" href="' + minFilePath + '">';
+                }
+              },
+              js: function (filePath) {
+                var minFilePath = filePath.replace('.js', '.min.js');
+                var fullPath = path.join(process.cwd(), 'public', minFilePath);
+                if (!fs.existsSync(fullPath)) {
+                  return '<script type="text/javascript" src="' + filePath + '"></script>';
+                } else {
+                  return '<script type="text/javascript" src="' + minFilePath + '"></script>';
+                }
               }
             }
           }
@@ -323,7 +329,7 @@ module.exports = function (grunt) {
   });
 
   // Lint project files and minify them into two production files.
-  grunt.registerTask('build', ['env:dev', 'wiredep', 'lint', 'ngAnnotate', 'uglify', 'cssmin']);
+  grunt.registerTask('build', ['env:dev', 'wiredep:production', 'lint', 'ngAnnotate', 'uglify', 'cssmin']);
 
   // Run the project tests
   grunt.registerTask('test', ['env:test', 'lint', 'mkdir:upload', 'copy:localConfig', 'server', 'mochaTest', 'karma:unit', 'protractor']);
@@ -334,7 +340,7 @@ module.exports = function (grunt) {
   grunt.registerTask('coverage', ['env:test', 'lint', 'mocha_istanbul:coverage', 'karma:unit']);
 
   // Run the project in development mode
-  grunt.registerTask('default', ['env:dev', 'lint', 'mkdir:upload', 'copy:localConfig', 'concurrent:default']);
+  grunt.registerTask('default', ['env:dev', 'wiredep:dev', 'lint', 'mkdir:upload', 'copy:localConfig', 'concurrent:default']);
 
   // Run the project in debug mode
   grunt.registerTask('debug', ['env:dev', 'lint', 'mkdir:upload', 'copy:localConfig', 'concurrent:debug']);

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -11,6 +11,8 @@ var _ = require('lodash'),
   path = require('path'),
   wiredep = require('wiredep');
 
+var karmaConfigFile = 'karma.conf.js';
+
 module.exports = function (grunt) {
   // Project Configuration
   grunt.initConfig({
@@ -79,6 +81,16 @@ module.exports = function (grunt) {
       dev: {
         src: 'modules/core/server/views/layout.server.view.html',
         ignorePath: /.*public\//
+      },
+      test: {
+        src: karmaConfigFile,
+        fileTypes: {
+          js: {
+            replace: {
+              js: '\'{{filePath}}\','
+            }
+          }
+        }
       },
       production: {
         src: 'modules/core/server/views/layout.server.view.html',
@@ -224,7 +236,7 @@ module.exports = function (grunt) {
     },
     karma: {
       unit: {
-        configFile: 'karma.conf.js'
+        configFile: karmaConfigFile
       }
     },
     protractor: {
@@ -332,12 +344,12 @@ module.exports = function (grunt) {
   grunt.registerTask('build', ['env:dev', 'wiredep:production', 'lint', 'ngAnnotate', 'uglify', 'cssmin']);
 
   // Run the project tests
-  grunt.registerTask('test', ['env:test', 'lint', 'mkdir:upload', 'copy:localConfig', 'server', 'mochaTest', 'karma:unit', 'protractor']);
+  grunt.registerTask('test', ['env:test', 'wiredep:test', 'lint', 'mkdir:upload', 'copy:localConfig', 'server', 'mochaTest', 'karma:unit', 'protractor']);
   grunt.registerTask('test:server', ['env:test', 'lint', 'server', 'mochaTest']);
-  grunt.registerTask('test:client', ['env:test', 'lint', 'karma:unit']);
-  grunt.registerTask('test:e2e', ['env:test', 'lint', 'dropdb', 'server', 'protractor']);
+  grunt.registerTask('test:client', ['env:test', 'wiredep:test', 'lint', 'karma:unit']);
+  grunt.registerTask('test:e2e', ['env:test', 'wiredep:test', 'lint', 'dropdb', 'server', 'protractor']);
   // Run project coverage
-  grunt.registerTask('coverage', ['env:test', 'lint', 'mocha_istanbul:coverage', 'karma:unit']);
+  grunt.registerTask('coverage', ['env:test', 'wiredep:test', 'lint', 'mocha_istanbul:coverage', 'karma:unit']);
 
   // Run the project in development mode
   grunt.registerTask('default', ['env:dev', 'wiredep:dev', 'lint', 'mkdir:upload', 'copy:localConfig', 'concurrent:default']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -214,44 +214,44 @@ gulp.task('imagemin', function () {
 
 // wiredep task to default
 gulp.task('wiredep', function () {
-  return gulp.src('config/assets/default.js')
+  return gulp.src('modules/core/server/views/layout.server.view.html')
     .pipe(wiredep({
-      ignorePath: '../../'
+      ignorePath: /.*public\//
     }))
-    .pipe(gulp.dest('config/assets/'));
+    .pipe(gulp.dest('modules/core/server/views/'));
 });
 
 // wiredep task to production
 gulp.task('wiredep:prod', function () {
-  return gulp.src('config/assets/production.js')
+  return gulp.src('modules/core/server/views/layout.server.view.html')
     .pipe(wiredep({
-      ignorePath: '../../',
+      ignorePath: /.*public\//,
       fileTypes: {
-        js: {
+        html: {
           replace: {
             css: function (filePath) {
               var minFilePath = filePath.replace('.css', '.min.css');
-              var fullPath = path.join(process.cwd(), minFilePath);
+              var fullPath = path.join(process.cwd(), 'public', minFilePath);
               if (!fs.existsSync(fullPath)) {
-                return '\'' + filePath + '\',';
+                return '<link rel="stylesheet" href="' + filePath + '">';
               } else {
-                return '\'' + minFilePath + '\',';
+                return '<link rel="stylesheet" href="' + minFilePath + '">';
               }
             },
             js: function (filePath) {
               var minFilePath = filePath.replace('.js', '.min.js');
-              var fullPath = path.join(process.cwd(), minFilePath);
+              var fullPath = path.join(process.cwd(), 'public', minFilePath);
               if (!fs.existsSync(fullPath)) {
-                return '\'' + filePath + '\',';
+                return '<script type="text/javascript" src="' + filePath + '"></script>';
               } else {
-                return '\'' + minFilePath + '\',';
+                return '<script type="text/javascript" src="' + minFilePath + '"></script>';
               }
             }
           }
         }
       }
     }))
-    .pipe(gulp.dest('config/assets/'));
+    .pipe(gulp.dest('modules/core/server/views/'));
 });
 
 // Copy local development environment config example
@@ -406,7 +406,7 @@ gulp.task('test:e2e', function (done) {
 
 // Run the project in development mode
 gulp.task('default', function (done) {
-  runSequence('env:dev', ['copyLocalEnvConfig', 'makeUploadsDir'], 'lint', ['nodemon', 'watch'], done);
+  runSequence('env:dev', ['copyLocalEnvConfig', 'makeUploadsDir'], 'wiredep', 'lint', ['nodemon', 'watch'], done);
 });
 
 // Run the project in debug mode

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,8 @@ var _ = require('lodash'),
   KarmaServer = require('karma').Server;
 
 // Local settings
-var changedTestFiles = [];
+var changedTestFiles = [],
+  karmaConfigFile = __dirname + '/karma.conf.js';
 
 // Set NODE_ENV to 'test'
 gulp.task('env:test', function () {
@@ -221,6 +222,20 @@ gulp.task('wiredep', function () {
     .pipe(gulp.dest('modules/core/server/views/'));
 });
 
+gulp.task('wiredep:test', function () {
+  return gulp.src(karmaConfigFile)
+    .pipe(wiredep({
+      fileTypes: {
+        js: {
+          replace: {
+            js: '\'{{filePath}}\','
+          }
+        }
+      }
+    }))
+    .pipe(gulp.dest(__dirname));
+});
+
 // wiredep task to production
 gulp.task('wiredep:prod', function () {
   return gulp.src('modules/core/server/views/layout.server.view.html')
@@ -324,7 +339,7 @@ gulp.task('mocha', function (done) {
 // Karma test runner task
 gulp.task('karma', function (done) {
   new KarmaServer({
-    configFile: __dirname + '/karma.conf.js',
+    configFile: karmaConfigFile,
     singleRun: true
   }, done).start();
 });
@@ -384,7 +399,7 @@ gulp.task('build', function (done) {
 
 // Run the project tests
 gulp.task('test', function (done) {
-  runSequence('env:test', 'test:server', 'karma', 'nodemon', 'protractor', done);
+  runSequence('env:test', 'wiredep:test', 'test:server', 'karma', 'nodemon', 'protractor', done);
 });
 
 gulp.task('test:server', function (done) {
@@ -397,11 +412,11 @@ gulp.task('test:server:watch', function (done) {
 });
 
 gulp.task('test:client', function (done) {
-  runSequence('env:test', 'lint', 'dropdb', 'karma', done);
+  runSequence('env:test', 'wiredep:test', 'lint', 'dropdb', 'karma', done);
 });
 
 gulp.task('test:e2e', function (done) {
-  runSequence('env:test', 'lint', 'dropdb', 'nodemon', 'protractor', done);
+  runSequence('env:test', 'wiredep:test', 'lint', 'dropdb', 'nodemon', 'protractor', done);
 });
 
 // Run the project in development mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,6 +13,21 @@ if (testConfig.coverage) {
   karmaReporters.push('coverage');
 }
 
+var bowerDependencies = [
+  // bower:js
+  'public/lib/angular/angular.js',
+  'public/lib/angular-animate/angular-animate.js',
+  'public/lib/angular-bootstrap/ui-bootstrap-tpls.js',
+  'public/lib/angular-file-upload/dist/angular-file-upload.min.js',
+  'public/lib/angular-messages/angular-messages.js',
+  'public/lib/angular-mocks/angular-mocks.js',
+  'public/lib/angular-resource/angular-resource.js',
+  'public/lib/angular-ui-router/release/angular-ui-router.js',
+  'public/lib/owasp-password-strength-test/owasp-password-strength-test.js',
+  // endbower
+  'public/lib/angular-mocks/angular-mocks.js'
+];
+
 // Karma configuration
 module.exports = function (karmaConfig) {
   karmaConfig.set({
@@ -39,7 +54,7 @@ module.exports = function (karmaConfig) {
     },
 
     // List of files / patterns to load in the browser
-    files: _.union(defaultAssets.client.lib.js, defaultAssets.client.lib.tests, defaultAssets.client.js, testAssets.tests.client, defaultAssets.client.views),
+    files: _.union(bowerDependencies, defaultAssets.client.js, testAssets.tests.client, defaultAssets.client.views),
 
     // Test results reporter to use
     // Possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'

--- a/modules/core/server/views/layout.server.view.html
+++ b/modules/core/server/views/layout.server.view.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en" ng-strict-di>
 <head>
   <meta charset="utf-8">
@@ -31,6 +31,12 @@
   <!-- Fav Icon -->
   <link href="{{favicon}}" rel="shortcut icon" type="image/x-icon">
 
+  <!-- Application depencies -->
+  <!-- bower:css -->
+  <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap-theme.min.css">
+  <!-- endbower -->
+
   <!-- Application CSS Files -->
   {% for cssFile in cssFiles %}<link rel="stylesheet" href="{{cssFile}}">{% endfor %}
 </head>
@@ -50,6 +56,19 @@
 
   <!--Load The Socket.io File-->
   <script type="text/javascript" src="/socket.io/socket.io.js"></script>
+
+  <!-- Application Dependencies -->
+  <!-- bower:js -->
+  <script type="text/javascript" src="lib/angular/angular.min.js"></script>
+  <script type="text/javascript" src="lib/angular-animate/angular-animate.min.js"></script>
+  <script type="text/javascript" src="lib/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
+  <script type="text/javascript" src="lib/angular-file-upload/dist/angular-file-upload.min.js"></script>
+  <script type="text/javascript" src="lib/angular-messages/angular-messages.min.js"></script>
+  <script type="text/javascript" src="lib/angular-mocks/angular-mocks.js"></script>
+  <script type="text/javascript" src="lib/angular-resource/angular-resource.min.js"></script>
+  <script type="text/javascript" src="lib/angular-ui-router/release/angular-ui-router.min.js"></script>
+  <script type="text/javascript" src="lib/owasp-password-strength-test/owasp-password-strength-test.js"></script>
+  <!-- endbower -->
 
   <!--Application JavaScript Files-->
   {% for jsFile in jsFiles %}<script type="text/javascript" src="{{jsFile}}"></script>{% endfor %}


### PR DESCRIPTION
Wiring html source directly doesn't fix issue #1360 completely as [karma.conf.js](https://github.com/meanjs/mean/blob/master/karma.conf.js#L42) still relies on it.

It also can be (and has to be) wired using wiredep, but the lint issue of wiring array arises there.

Any thoughts ?