### PR TITLE
Sanitise user

### DIFF
--- a/modules/users/server/controllers/admin.server.controller.js
+++ b/modules/users/server/controllers/admin.server.controller.js
@@ -59,7 +59,7 @@ exports.delete = function (req, res) {
  * List of Users
  */
 exports.list = function (req, res) {
-  User.find({}, '-salt -password').sort('-created').populate('user', 'displayName').exec(function (err, users) {
+  User.find({}, '-salt -password -providerData').sort('-created').populate('user', 'displayName').exec(function (err, users) {
     if (err) {
       return res.status(400).send({
         message: errorHandler.getErrorMessage(err)
@@ -80,7 +80,7 @@ exports.userByID = function (req, res, next, id) {
     });
   }
 
-  User.findById(id, '-salt -password').exec(function (err, user) {
+  User.findById(id, '-salt -password -providerData').exec(function (err, user) {
     if (err) {
       return next(err);
     } else if (!user) {

--- a/modules/users/server/controllers/users/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users/users.profile.server.controller.js
@@ -10,7 +10,8 @@ var _ = require('lodash'),
   mongoose = require('mongoose'),
   multer = require('multer'),
   config = require(path.resolve('./config/config')),
-  User = mongoose.model('User');
+  User = mongoose.model('User'),
+  validator = require('validator');
 
 /**
  * Update user details
@@ -101,5 +102,23 @@ exports.changeProfilePicture = function (req, res) {
  * Send User
  */
 exports.me = function (req, res) {
-  res.json(req.user || null);
+  // Sanitize the user - short term solution. Copied from core.server.controller.js
+  // TODO create proper passport mock: See https://gist.github.com/mweibel/5219403
+  var safeUserObject = null;
+  if (req.user) {
+    safeUserObject = {
+      displayName: validator.escape(req.user.displayName),
+      provider: validator.escape(req.user.provider),
+      username: validator.escape(req.user.username),
+      created: req.user.created.toString(),
+      roles: req.user.roles,
+      profileImageURL: req.user.profileImageURL,
+      email: validator.escape(req.user.email),
+      lastName: validator.escape(req.user.lastName),
+      firstName: validator.escape(req.user.firstName),
+      additionalProvidersData: req.user.additionalProvidersData
+    };
+  }
+
+  res.json(safeUserObject || null);
 };


### PR DESCRIPTION
feat(users): Routes are currently leaking access tokens

Authentication routes use route /api/users/me and /api/users/ (for admins). Maybe a mock closer to passport like: https://gist.github.com/mweibel/5219403 would be nice. In the meanwhile this should make the returned user object safer. See:

https://www.facebook.com/FacebookforDevelopers/videos/10152795636318553/

(specifically the part about stealing access tokens). I re-used code from core:

modules/core/server/controllers/core.server.controller.js

Fixes n/a - general security improvement