### PR TITLE
fix(chat): fixed profile image not displaying properly on disconnect

### DIFF
--- a/modules/chat/server/sockets/chat.server.socket.config.js
+++ b/modules/chat/server/sockets/chat.server.socket.config.js
@@ -28,6 +28,7 @@ module.exports = function (io, socket) {
       type: 'status',
       text: 'disconnected',
       created: Date.now(),
+      profileImageURL: socket.request.user.profileImageURL,
       username: socket.request.user.username
     });
   });


### PR DESCRIPTION
In the chat example, the profileImageURL is not sent to clients when a user disconnects.

Before:

![before picture](https://cloud.githubusercontent.com/assets/5142948/17460247/76ac9280-5c2b-11e6-9387-2c4f8b92d9fc.png)

After:

![after picture](https://cloud.githubusercontent.com/assets/5142948/17460251/b61329fc-5c2b-11e6-9916-55ce9008a8ca.png)
