### PR TITLE
Fix(server): Remove unused loadModels()

### DIFF
--- a/config/lib/app.js
+++ b/config/lib/app.js
@@ -19,10 +19,6 @@ function seedDB() {
 // Initialize Models
 mongoose.loadModels(seedDB);
 
-module.exports.loadModels = function loadModels() {
-  mongoose.loadModels();
-};
-
 module.exports.init = function init(callback) {
   mongoose.connect(function (db) {
     // Initialize express


### PR DESCRIPTION
Remove unused `loadModels()` from app.js, as it doesn't seem to be used anywhere.

— or am I missing something?

It was added here: https://github.com/meanjs/mean/commit/edb62344bc4af3cb28c3469dc7463c13a2fc76a1