### PR TITLE
fix(articles): Article controllers name conflicts

### DIFF
--- a/modules/articles/client/config/articles-admin.client.routes.js
+++ b/modules/articles/client/config/articles-admin.client.routes.js
@@ -17,7 +17,7 @@
       .state('admin.articles.list', {
         url: '',
         templateUrl: 'modules/articles/client/views/admin/list-articles.client.view.html',
-        controller: 'ArticlesListController',
+        controller: 'ArticlesAdminListController',
         controllerAs: 'vm',
         data: {
           roles: ['admin']
@@ -26,7 +26,7 @@
       .state('admin.articles.create', {
         url: '/create',
         templateUrl: 'modules/articles/client/views/admin/form-article.client.view.html',
-        controller: 'ArticlesController',
+        controller: 'ArticlesAdminController',
         controllerAs: 'vm',
         data: {
           roles: ['admin']
@@ -38,7 +38,7 @@
       .state('admin.articles.edit', {
         url: '/:articleId/edit',
         templateUrl: 'modules/articles/client/views/admin/form-article.client.view.html',
-        controller: 'ArticlesController',
+        controller: 'ArticlesAdminController',
         controllerAs: 'vm',
         data: {
           roles: ['admin']

--- a/modules/articles/client/controllers/admin/article.client.controller.js
+++ b/modules/articles/client/controllers/admin/article.client.controller.js
@@ -3,11 +3,11 @@
 
   angular
     .module('articles.admin')
-    .controller('ArticlesController', ArticlesController);
+    .controller('ArticlesAdminController', ArticlesAdminController);
 
-  ArticlesController.$inject = ['$scope', '$state', '$window', 'articleResolve', 'Authentication'];
+  ArticlesAdminController.$inject = ['$scope', '$state', '$window', 'articleResolve', 'Authentication'];
 
-  function ArticlesController($scope, $state, $window, article, Authentication) {
+  function ArticlesAdminController($scope, $state, $window, article, Authentication) {
     var vm = this;
 
     vm.article = article;

--- a/modules/articles/client/controllers/admin/list-articles.client.controller.js
+++ b/modules/articles/client/controllers/admin/list-articles.client.controller.js
@@ -2,12 +2,12 @@
   'use strict';
 
   angular
-    .module('articles')
-    .controller('ArticlesListController', ArticlesListController);
+    .module('articles.admin')
+    .controller('ArticlesAdminListController', ArticlesAdminListController);
 
-  ArticlesListController.$inject = ['ArticlesService'];
+  ArticlesAdminListController.$inject = ['ArticlesService'];
 
-  function ArticlesListController(ArticlesService) {
+  function ArticlesAdminListController(ArticlesService) {
     var vm = this;
 
     vm.articles = ArticlesService.query();

--- a/modules/articles/tests/client/admin.articles.client.controller.tests.js
+++ b/modules/articles/tests/client/admin.articles.client.controller.tests.js
@@ -1,9 +1,9 @@
 ﻿(function () {
   'use strict';
 
-  describe('Articles Controller Tests', function () {
+  describe('Articles Admin Controller Tests', function () {
     // Initialize global variables
-    var ArticlesController,
+    var ArticlesAdminController,
       $scope,
       $httpBackend,
       $state,
@@ -59,7 +59,7 @@
       };
 
       // Initialize the Articles controller.
-      ArticlesController = $controller('ArticlesController as vm', {
+      ArticlesAdminController = $controller('ArticlesAdminController as vm', {
         $scope: $scope,
         articleResolve: {}
       });

--- a/modules/articles/tests/client/admin.articles.client.routes.tests.js
+++ b/modules/articles/tests/client/admin.articles.client.routes.tests.js
@@ -59,7 +59,7 @@
 
       describe('Create Route', function () {
         var createstate,
-          ArticlesController,
+          ArticlesAdminController,
           mockArticle;
 
         beforeEach(inject(function ($controller, $state, $templateCache) {
@@ -70,7 +70,7 @@
           mockArticle = new ArticlesService();
 
           // Initialize Controller
-          ArticlesController = $controller('ArticlesController as vm', {
+          ArticlesAdminController = $controller('ArticlesAdminController as vm', {
             $scope: $scope,
             articleResolve: mockArticle
           });
@@ -105,7 +105,7 @@
 
       describe('Edit Route', function () {
         var editstate,
-          ArticlesController,
+          ArticlesAdminController,
           mockArticle;
 
         beforeEach(inject(function ($controller, $state, $templateCache) {
@@ -120,7 +120,7 @@
           });
 
           // Initialize Controller
-          ArticlesController = $controller('ArticlesController as vm', {
+          ArticlesAdminController = $controller('ArticlesAdminController as vm', {
             $scope: $scope,
             articleResolve: mockArticle
           });

--- a/modules/articles/tests/client/admin.list.articles.client.controller.tests.js
+++ b/modules/articles/tests/client/admin.list.articles.client.controller.tests.js
@@ -3,7 +3,7 @@
 
   describe('Admin Articles List Controller Tests', function () {
     // Initialize global variables
-    var ArticlesListController,
+    var ArticlesAdminListController,
       $scope,
       $httpBackend,
       $state,
@@ -59,7 +59,7 @@
       };
 
       // Initialize the Articles List controller.
-      ArticlesListController = $controller('ArticlesListController as vm', {
+      ArticlesAdminListController = $controller('ArticlesAdminListController as vm', {
         $scope: $scope
       });
 


### PR DESCRIPTION
Fixes the naming conflicts for the Articles controllers.

Due to how Angular injects the controllers into the StateProvider,
naming conflicts were caused between the Articles public & admin module
controllers.

To resolve the issue the referenced controllers in the Articles admin
route configurations must be unique, and match up with the Admin
controllers.