### PR TITLE
fix(users): specify a digest with crypto.pbkdf2Sync

### DIFF
--- a/modules/users/server/models/user.server.model.js
+++ b/modules/users/server/models/user.server.model.js
@@ -135,7 +135,7 @@ UserSchema.pre('validate', function (next) {
  */
 UserSchema.methods.hashPassword = function (password) {
   if (this.salt && password) {
-    return crypto.pbkdf2Sync(password, new Buffer(this.salt, 'base64'), 10000, 64).toString('base64');
+    return crypto.pbkdf2Sync(password, new Buffer(this.salt, 'base64'), 10000, 64, 'SHA1').toString('base64');
   } else {
     return password;
   }


### PR DESCRIPTION
Fixes Node v6 crypto deprecation warning  `crypto.pbkdf2 without specifying a digest is deprecated. Please specify a digest`