### PR TITLE
Add data container for docker-compose and update to docker compose version 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,27 @@
-web:
-  restart: always
-  build: .
-  container_name: meanjs
-  command: npm start
-  links:
-   - db
-  ports:
-   - "3000:3000"
-   - "5858:5858"
-   - "35729:35729"
-  environment:
-   - NODE_ENV=development
-  volumes:
-   - ./:/opt/mean.js
-   - /opt/mean.js/node_modules
-   - /opt/mean.js/public
-   - /opt/mean.js/uploads
-db:
-  image: mongo:3.2
-  container_name: db_1
-  restart: always
-  ports:
-   - "27017:27017"
-  volumes:
-   - db:/data/db
+version: '2'
+services:
+  web:
+    restart: always
+    build: .
+    container_name: meanjs
+    command: npm start
+    links:
+     - db
+    ports:
+     - "3000:3000"
+     - "5858:5858"
+     - "35729:35729"
+    environment:
+     - NODE_ENV=development
+     - DB_1_PORT_27017_TCP_ADDR=db
+    volumes:
+     - ./:/opt/mean.js
+     - /opt/mean.js/node_modules
+     - /opt/mean.js/public
+     - /opt/mean.js/uploads
+  db:
+    image: mongo:3.2
+    container_name: db_1
+    restart: always
+    ports:
+     - "27017:27017"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     volumes_from:
      - web-data
   web-data:
-    image: busybox:latest
+    build: .
     volumes:
      - ./:/opt/mean.js
      - /opt/mean.js/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
      - /opt/mean.js/node_modules
      - /opt/mean.js/public
      - /opt/mean.js/uploads
+    depends_on:
+      - db
   db:
     image: mongo:3.2
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,15 @@ services:
      - /opt/mean.js/uploads
   db:
     image: mongo:3.2
-    container_name: db_1
     restart: always
     ports:
      - "27017:27017"
+    volumes_from:
+      - db-data
+  db-data:
+    image: mongo:3.2
+    volumes:
+      - /data/db
+      - /var/lib/mongodb
+      - /var/log/mongodb
+    entrypoint: /bin/true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
      - web-data
   web-data:
     build: .
+    entrypoint: /bin/true
     volumes:
      - ./:/opt/mean.js
      - /opt/mean.js/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     build: .
     container_name: meanjs
     command: npm start
-    links:
-     - db
     ports:
      - "3000:3000"
      - "5858:5858"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     restart: always
     build: .
     container_name: meanjs
-    command: npm start
     ports:
      - "3000:3000"
      - "5858:5858"
@@ -12,13 +11,17 @@ services:
     environment:
      - NODE_ENV=development
      - DB_1_PORT_27017_TCP_ADDR=db
+    depends_on:
+     - db
+    volumes_from:
+     - web-data
+  web-data:
+    image: busybox:latest
     volumes:
      - ./:/opt/mean.js
      - /opt/mean.js/node_modules
      - /opt/mean.js/public
      - /opt/mean.js/uploads
-    depends_on:
-      - db
   db:
     image: mongo:3.2
     restart: always


### PR DESCRIPTION
feat(deploy) Add data container for docker-compose and update to docker compose version 2.

Add data container for mongodb
Add data container for web data
Update to compose version 2
Use networking of compose version 2 (remove links)
Use depends_on for containers

Fixes #1434