### PR TITLE
feat(users): Profile picture cropping, mobile uploading and progress bar

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,8 @@
     "angular-resource": "~1.5.0",
     "angular-ui-router": "~0.2.18",
     "bootstrap": "~3.3.6",
+    "ng-file-upload": "^12.1.0",
+    "ng-img-crop": "ngImgCrop#^0.3.2",
     "owasp-password-strength-test": "~1.3.0"
   },
   "overrides": {

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,6 @@
     "angular": "~1.5.0",
     "angular-animate": "~1.5.0",
     "angular-bootstrap": "~1.2.1",
-    "angular-file-upload": "~2.2.0",
     "angular-messages": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "angular-resource": "~1.5.0",

--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -9,6 +9,7 @@ module.exports = {
         // bower:css
         'public/lib/bootstrap/dist/css/bootstrap.css',
         'public/lib/bootstrap/dist/css/bootstrap-theme.css',
+        'public/lib/ng-img-crop/compile/unminified/ng-img-crop.css'
         // endbower
       ],
       js: [
@@ -16,7 +17,8 @@ module.exports = {
         'public/lib/angular/angular.js',
         'public/lib/angular-animate/angular-animate.js',
         'public/lib/angular-bootstrap/ui-bootstrap-tpls.js',
-        'public/lib/angular-file-upload/dist/angular-file-upload.min.js',
+        'public/lib/ng-file-upload/ng-file-upload.js',
+        'public/lib/ng-img-crop/compile/unminified/ng-img-crop.js',
         'public/lib/angular-messages/angular-messages.js',
         'public/lib/angular-mocks/angular-mocks.js',
         'public/lib/angular-resource/angular-resource.js',

--- a/modules/core/client/app/config.js
+++ b/modules/core/client/app/config.js
@@ -5,7 +5,7 @@
 
   var service = {
     applicationModuleName: applicationModuleName,
-    applicationModuleVendorDependencies: ['ngResource', 'ngAnimate', 'ngMessages', 'ui.router', 'ui.bootstrap', 'angularFileUpload'],
+    applicationModuleVendorDependencies: ['ngResource', 'ngAnimate', 'ngMessages', 'ui.router', 'ui.bootstrap', 'ngFileUpload', 'ngImgCrop'],
     registerModule: registerModule
   };
 

--- a/modules/users/client/css/users.css
+++ b/modules/users/client/css/users.css
@@ -34,3 +34,8 @@
   min-height: 150px;
   max-height: 150px;
 }
+.cropArea {
+    background: #E4E4E4;
+    width: 300px;
+    height: 300px;
+}

--- a/modules/users/client/views/settings/change-profile-picture.client.view.html
+++ b/modules/users/client/views/settings/change-profile-picture.client.view.html
@@ -2,17 +2,26 @@
   <div class="col-xs-offset-1 col-xs-10 col-md-offset-3 col-md-4">
     <form class="signin form-horizontal">
       <fieldset>
+        <div ng-show="vm.fileSelected" class="text-center form-group">
+          <p>Crop your picture then press upload below:</p>
+          <div ngf-drop ng-model="picFile" ngf-pattern="image/*" class="cropArea">
+            <img-crop image="picFile | ngfDataUrl" result-image="croppedDataUrl" ng-init="croppedDataUrl=''"></img-crop>
+          </div>
+        </div>
         <div class="form-group text-center">
-          <img ng-src="{{vm.imageURL}}" alt="{{vm.user.displayName}}" class="img-thumbnail user-profile-picture">
+          <img ng-src="{{vm.fileSelected ? croppedDataUrl : vm.user.profileImageURL}}" alt="{{vm.user.displayName}}" class="img-thumbnail user-profile-picture" ngf-drop>
         </div>
-        <div class="text-center form-group" ng-hide="vm.uploader.queue.length">
-          <span class="btn btn-default btn-file">
-              Select Image <input type="file" nv-file-select uploader="vm.uploader">
-          </span>
+        <div ng-show="!vm.fileSelected" class="text-center form-group">
+          <button class="btn btn-default btn-file" ngf-select="vm.fileSelected = true; vm.success = null" ng-model="picFile" accept="image/*">Select Picture</button>
         </div>
-        <div class="text-center form-group" ng-show="vm.uploader.queue.length">
-          <button class="btn btn-primary" ng-click="vm.uploadProfilePicture();">Upload</button>
-          <button class="btn btn-default" ng-click="vm.cancelUpload();">Cancel</button>
+        <div ng-show="vm.fileSelected" class="text-center form-group">
+          <button class="btn btn-primary" ng-click="vm.upload(croppedDataUrl, picFile.name)">Upload</button>
+          <button class="btn btn-default" ng-click="vm.fileSelected = false">Cancel</button>
+        </div>
+        <div ng-show="vm.fileSelected" class="progress text-center">
+          <div class="progress-bar" role="progressbar" aria-valuenow="{{vm.progress}}" aria-valuemin="0" aria-valuemax="100" style="width:{{vm.progress}}%" ng-bind="vm.progress + '%'">
+            <span class="sr-only">{{vm.progress}}% Complete</span>
+          </div>
         </div>
         <div ng-show="vm.success" class="text-center text-success">
           <strong>Profile Picture Changed Successfully</strong>


### PR DESCRIPTION
feat(users): Profile picture cropping, mobile uploading and progress bar

Improvements to the Change Profile Picture page including:
 - The option to take a camera pic and upload it is now offered on mobile
 - Large images (such as those taken from a camera) no longer crash the page
 - Add ability to crop pictures using [ngImgCrop](https://github.com/alexk111/ngImgCrop)
 - Add progress bar during uploading
 - Large images are now properly resized to thumbnails
 - Much of this was accomplished by switching from the [angular-file-upload](https://github.com/nervgh/angular-file-upload) 
module to the far more fully-featured and frequently-updated [ng-file-upload](https://github.com/danialfarid/ng-file-upload)