### PR TITLE
feat(core): disable Angular debug data in production

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -39,6 +39,7 @@ module.exports.initLocalVariables = function (app) {
   app.locals.livereload = config.livereload;
   app.locals.logo = config.logo;
   app.locals.favicon = config.favicon;
+  app.locals.env = process.env.NODE_ENV;
 
   // Passing the request url to environment locals
   app.use(function (req, res, next) {

--- a/modules/core/client/app/config.js
+++ b/modules/core/client/app/config.js
@@ -4,6 +4,7 @@
   var applicationModuleName = 'mean';
 
   var service = {
+    applicationEnvironment: window.env,
     applicationModuleName: applicationModuleName,
     applicationModuleVendorDependencies: ['ngResource', 'ngAnimate', 'ngMessages', 'ui.router', 'ui.bootstrap', 'ngFileUpload', 'ngImgCrop'],
     registerModule: registerModule

--- a/modules/core/client/app/init.js
+++ b/modules/core/client/app/init.js
@@ -10,13 +10,17 @@
     .module(app.applicationModuleName)
     .config(bootstrapConfig);
 
-  function bootstrapConfig($locationProvider, $httpProvider) {
+  function bootstrapConfig($compileProvider, $locationProvider, $httpProvider) {
     $locationProvider.html5Mode(true).hashPrefix('!');
 
     $httpProvider.interceptors.push('authInterceptor');
+
+    // Disable debug data for production environment
+    // @link https://docs.angularjs.org/guide/production
+    $compileProvider.debugInfoEnabled(app.applicationEnvironment !== 'production');
   }
 
-  bootstrapConfig.$inject = ['$locationProvider', '$httpProvider'];
+  bootstrapConfig.$inject = ['$compileProvider', '$locationProvider', '$httpProvider'];
 
   // Then define the init function for starting up the application
   angular.element(document).ready(init);

--- a/modules/core/server/views/layout.server.view.html
+++ b/modules/core/server/views/layout.server.view.html
@@ -45,7 +45,8 @@
 
   <!--Embedding The User Object-->
   <script type="text/javascript">
-    var user = {{ user | json | safe }};
+    var user = {{ user | json | safe }},
+        env = "{{ env }}";
   </script>
 
   <!--Load The Socket.io File-->


### PR DESCRIPTION
Disable Angular debug data in production for a significant performance boost.

Passes environment variable from template to app config and from there to Angular bootstrap config.

https://docs.angularjs.org/guide/production#disabling-debug-data

See #1294