### PR TITLE
feat(build): Modify Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ os:
 # NodeJS v4 requires gcc 4.8
 env:
   - NODE_ENV=travis CXX="g++-4.8" CC="gcc-4.8"
-matrix:
-  allow_failures:
-    - node_js: 6
 services:
   - mongodb
 # gcc 4.8 requires ubuntu-toolchain-r-test


### PR DESCRIPTION
Remove Node.js v6 from `allow_failures` matrix at Travis config.

Seems to be passing anyway and v6 is already production ready.