### PR TITLE
fix(tests): Reorganized coverage tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
 after_script:
   - nsp audit-package
   - gulp test:coverage
+  - node_modules/.bin/lcov-result-merger 'coverage/**/lcov.info' | node_modules/coveralls/bin/coveralls.js
 notifications:
   webhooks:
     urls:

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -92,7 +92,5 @@ module.exports = {
         roles: ['user', 'admin']
       }
     }
-  },
-  // This config is set to true during gulp coverage
-  coverage: process.env.COVERAGE || false
+  }
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,25 +9,13 @@ var _ = require('lodash'),
   testConfig = require('./config/env/test'),
   karmaReporters = ['progress'];
 
-if (testConfig.coverage) {
-  karmaReporters.push('coverage');
-}
-
 // Karma configuration
 module.exports = function (karmaConfig) {
   karmaConfig.set({
-    // Frameworks to use
     frameworks: ['jasmine'],
 
     preprocessors: {
-      'modules/*/client/views/**/*.html': ['ng-html2js'],
-      'modules/core/client/app/config.js': ['coverage'],
-      'modules/core/client/app/init.js': ['coverage'],
-      'modules/*/client/*.js': ['coverage'],
-      'modules/*/client/config/*.js': ['coverage'],
-      'modules/*/client/controllers/*.js': ['coverage'],
-      'modules/*/client/directives/*.js': ['coverage'],
-      'modules/*/client/services/*.js': ['coverage']
+      'modules/*/client/views/**/*.html': ['ng-html2js']
     },
 
     ngHtml2JsPreprocessor: {
@@ -44,20 +32,6 @@ module.exports = function (karmaConfig) {
     // Test results reporter to use
     // Possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
     reporters: karmaReporters,
-
-    // Configure the coverage reporter
-    coverageReporter: {
-      dir: 'coverage/client',
-      reporters: [
-        // Reporters not supporting the `file` property
-        { type: 'lcov', subdir: '.' },
-        // Output coverage to console
-        { type: 'text' }
-      ],
-      instrumenterOptions: {
-        istanbul: { noCompact: true }
-      }
-    },
 
     // Web server port
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "gulp-angular-templatecache": "~1.8.0",
     "gulp-autoprefixer": "~3.1.0",
     "gulp-concat": "~2.6.0",
-    "gulp-coveralls": "~0.1.4",
     "gulp-csslint": "~0.2.0",
     "gulp-csso": "~1.1.0",
     "gulp-eslint": "~2.0.0",


### PR DESCRIPTION
fix(tests): Reorganized coverage tests

Moved coverage configuration from karma.conf to the gulpfile:
- The server-side coverage tests are already configured in the gulpfile so I think the client-side ones should be too, cleaning up the karma.conf file.
- The previous method to tell karma to run coverage tests involved flipping an environment variable which karma.conf then read. I suspect that this is what caused client-side Travis builds not to send reports to coveralls

LCOV report file concatenation and sending to coveralls has been moved from the gulpfile to .travis.yml, as per @mleanos [suggestion](https://github.com/meanjs/mean/commit/7be191042066e58850899000ee02b6557d744c18#commitcomment-18891729)
- Now coverage tests can be run locally using gulp test:coverage without error if you don't have a coveralls account
- Unfortunately the Karma coverage summary cannot currently be printed to the console due to [a bug](https://github.com/karma-runner/karma/issues/1788) (well, it can be printed, but it causes the karma:coverage gulp task to hang for about 30 seconds).