### PR TITLE
Updating the dockerfile-production to build with gulp support

### DIFF
--- a/Dockerfile-production
+++ b/Dockerfile-production
@@ -34,7 +34,7 @@ WORKDIR /opt/mean.js
 # when the local package.json file changes.
 # Install npm packages
 ADD package.json /opt/mean.js/package.json
-RUN npm install --quiet --production
+RUN NODE_ENV=development npm install --quiet
 
 # Install bower packages
 ADD bower.json /opt/mean.js/bower.json


### PR DESCRIPTION
Gulp actually requires the gulp package and it's libraries to be installed, and this goes even if gulp or gulp-cli are installed globally. This is why the build fails.
The fix in this PR mitigates this by updating the Dockerfile-production to hint npm to install all dependencies.

Fixes #1453 