### PR TITLE
fix(core): Redirect to login page rather than 403 if not signed in

### DIFF
--- a/modules/core/client/config/core.client.route-filter.js
+++ b/modules/core/client/config/core.client.route-filter.js
@@ -25,7 +25,7 @@
 
         if (!allowed) {
           event.preventDefault();
-          if (Authentication.user !== undefined && typeof Authentication.user === 'object') {
+          if (Authentication.user !== null && typeof Authentication.user === 'object') {
             $state.transitionTo('forbidden');
           } else {
             $state.go('authentication.signin').then(function () {


### PR DESCRIPTION
feat(users): Redirect to login page rather than 403 if not signed in

Non-signed in users are being redirected to the unfriendly 403 forbidden page instead of the sign in page as should be the case. Fixed the tiny bug in the code that caused this to happen.