### PR TITLE
feat(users): Email verification

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -46,5 +46,6 @@ module.exports = {
         fileSize: 1 * 1024 * 1024 // Max file size in bytes (1 MB)
       }
     }
-  }
+  },
+  verifyUserEmail: true
 };

--- a/modules/users/client/config/users.client.routes.js
+++ b/modules/users/client/config/users.client.routes.js
@@ -123,6 +123,24 @@
         data: {
           pageTitle: 'Password reset form'
         }
+      })
+      .state('resendVerificationEmail', {
+        url: '/verification',
+        templateUrl: 'modules/users/client/views/verification/resend-verification-email.client.view.html',
+        controller: 'VerificationController',
+        controllerAs: 'vm',
+        data: {
+          pageTitle: 'Resend Verification Email'
+        }
+      })
+      .state('verification', {
+        url: '/verification/:token',
+        templateUrl: 'modules/users/client/views/verification/verify-account.client.view.html',
+        controller: 'VerificationController',
+        controllerAs: 'vm',
+        data: {
+          pageTitle: 'Verify Account'
+        }
       });
   }
 }());

--- a/modules/users/client/controllers/authentication.client.controller.js
+++ b/modules/users/client/controllers/authentication.client.controller.js
@@ -14,6 +14,7 @@
     vm.getPopoverMsg = PasswordValidator.getPopoverMsg;
     vm.signup = signup;
     vm.signin = signin;
+    vm.pleaseVerifyMessage = null;
     vm.callOauthProvider = callOauthProvider;
 
     // Get an eventual error defined in the URL query string:
@@ -34,11 +35,16 @@
       }
 
       $http.post('/api/auth/signup', vm.credentials).success(function (response) {
-        // If successful we assign the response to the global user model
-        vm.authentication.user = response;
+        // It's a message string if user needs to verify their account
+        if (typeof response === 'string') {
+          vm.pleaseVerifyMessage = response;
+        } else {
+        // We assign the response to the global user model
+          vm.authentication.user = response;
 
-        // And redirect to the previous or home page
-        $state.go($state.previous.state.name || 'home', $state.previous.params);
+          // And redirect to the previous or home page
+          $state.go($state.previous.state.name || 'home', $state.previous.params);
+        }
       }).error(function (response) {
         vm.error = response.message;
       });

--- a/modules/users/client/controllers/verification.client.controller.js
+++ b/modules/users/client/controllers/verification.client.controller.js
@@ -1,0 +1,68 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('users')
+    .controller('VerificationController', VerificationController);
+
+  VerificationController.$inject = ['$scope', '$state', '$http', 'Authentication', '$stateParams', '$location'];
+
+  function VerificationController($scope, $state, $http, Authentication, $stateParams, $location) {
+    var vm = this;
+
+    vm.authentication = Authentication;
+
+    vm.credentials = {};
+    vm.validateVerificationToken = validateVerificationToken;
+    vm.resendVerificationEmail = resendVerificationEmail;
+
+    // Get an eventual error defined in the URL query string:
+    vm.error = $location.search().err;
+
+    // If user is signed in then redirect back home
+    if (vm.authentication.user) {
+      $location.path('/');
+    }
+
+    // If we have a token, attempt to validate
+    if ($stateParams.token) {
+      vm.validateVerificationToken();
+    }
+
+    function resendVerificationEmail() {
+      vm.success = vm.error = null;
+      if (vm.credentials.email) {
+        $http.post('/api/auth/verify', { email: vm.credentials.email }).success(function(response) {
+          vm.credentials.email = null;
+          vm.success = response.message;
+        }).error(function(response) {
+          vm.credentials.email = null;
+          vm.error = response.message;
+        });
+      } else {
+        vm.error = 'Please enter an email address';
+      }
+    }
+
+    function validateVerificationToken() {
+      vm.success = vm.error = null;
+
+      var token = $stateParams.token;
+      var validTokenRe = /^([A-Za-z0-9]{48})$/g;
+      if (validTokenRe.test(token)) {
+
+        $http.get('/api/auth/verify/' + token).success(function(response) {
+          vm.credentials.email = null;
+          vm.success = response.message;
+        }).error(function(response) {
+          vm.credentials.email = null;
+          vm.error = response.message;
+        });
+      } else {
+        vm.error = 'Verification token was invalid.';
+      }
+    }
+
+  }
+}());
+

--- a/modules/users/client/views/authentication/signin.client.view.html
+++ b/modules/users/client/views/authentication/signin.client.view.html
@@ -23,11 +23,9 @@
           <a ui-sref="authentication.signup">Sign up</a>
         </div>
         <div class="text-center forgot-password">
-          <a ui-sref="password.forgot">Forgot your password?</a>
+          <a ui-sref="password.forgot">Forgot your password?</a> &#183; <a ui-sref="verification">Resend verification email</a>
         </div>
-        <p> 
-          &nbsp;
-        </p>
+        <br />
         <uib-alert type="danger" ng-show="vm.error" class="text-center text-danger">
           <span ng-bind="vm.error"></span>
         </uib-alert>

--- a/modules/users/client/views/authentication/signup.client.view.html
+++ b/modules/users/client/views/authentication/signup.client.view.html
@@ -42,17 +42,20 @@
             </div>
           </div>
         </div>
-        <div class="form-group" ng-show="!vm.userForm.password.$error.required">
+        <div class="form-group" ng-show="!vm.userForm.password.$error.required && !vm.pleaseVerifyMessage">
           <label>Password Requirements</label>
           <uib-progressbar value="requirementsProgress" type="{{requirementsColor}}"><span style="color:white; white-space:nowrap;">{{requirementsProgress}}%</span></uib-progressbar>
         </div>
-        <div class="text-center form-group">
+        <div ng-show="vm.error" class="alert alert-danger text-center">
+          <strong ng-bind="vm.error"></strong>
+        </div>
+        <div ng-show="vm.pleaseVerifyMessage" class="alert alert-success text-center">
+          <strong ng-bind="vm.pleaseVerifyMessage"></strong>
+        </div>
+        <div ng-show="!vm.pleaseVerifyMessage" class="text-center form-group">
           <button type="submit" class="btn btn-primary">Sign up</button>
           &nbsp; or&nbsp;
           <a ui-sref="authentication.signin" class="show-signup">Sign in</a>
-        </div>
-        <div ng-show="vm.error" class="text-center text-danger">
-          <strong ng-bind="vm.error"></strong>
         </div>
       </fieldset>
     </form>

--- a/modules/users/client/views/verification/resend-verification-email.client.view.html
+++ b/modules/users/client/views/verification/resend-verification-email.client.view.html
@@ -1,0 +1,23 @@
+<section class="auth row">
+  <h3 class="col-md-12 text-center">Resend account verification email</h3>
+  <p class="small text-center">Please enter the email address you signed up with:</p>
+  <div class="col-xs-offset-2 col-xs-8 col-md-offset-3 col-md-6">
+    <form class="signin form-horizontal" autocomplete="off">
+      <fieldset>
+        <div class="form-group">
+          <input type="text" id="username" name="email" class="form-control" data-ng-model="vm.credentials.email" placeholder="bob@example.com" autofocus>
+        </div>
+        <div class="alert alert-success text-center" ng-if="vm.success">
+          {{ vm.success }}
+        </div>
+        <div class="alert alert-danger text-center" ng-if="vm.error">
+        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+          {{ vm.error }}
+        </div>
+        <div class="text-center form-group" ng-if="!vm.success">
+          <button type="submit" class="btn btn-primary" ng-click="vm.resendVerificationEmail()">Submit</button>
+        </div>
+      </fieldset>
+    </form>
+  </div>
+</section>

--- a/modules/users/client/views/verification/verify-account.client.view.html
+++ b/modules/users/client/views/verification/verify-account.client.view.html
@@ -1,0 +1,30 @@
+<section style="margin-top: 20px;">
+
+  <div class="row text-center" ng-if="vm.success">
+    <div class="col-sm-12">
+      <div class="alert alert-success text-center">
+        <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+        {{ vm.success }}
+      </div>
+      <a ui-sref="authentication.signin">Continue to Sign In &raquo;</a>
+    </div>
+  </div>
+
+  <div class="row text-center" ng-if="vm.error">
+    <div class="col-sm-12">
+      <div class="alert alert-danger text-center">
+        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+        <strong>Sorry, your account could not be verified.</strong> {{ vm.error }}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-6">
+        <a ui-sref="verification({token: ''})">Resend verification email</a>
+      </div>
+      <div class="col-sm-6">
+        <a ui-sref="authentication.signin">Continue to Sign In</a>
+      </div>
+    </div>
+  </div>
+
+</section>

--- a/modules/users/server/controllers/users.server.controller.js
+++ b/modules/users/server/controllers/users.server.controller.js
@@ -12,5 +12,6 @@ module.exports = _.extend(
   require('./users/users.authentication.server.controller'),
   require('./users/users.authorization.server.controller'),
   require('./users/users.password.server.controller'),
-  require('./users/users.profile.server.controller')
+  require('./users/users.profile.server.controller'),
+  require('./users/users.verification.server.controller')
 );

--- a/modules/users/server/controllers/users/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users/users.authentication.server.controller.js
@@ -16,40 +16,6 @@ var noReturnUrls = [
 ];
 
 /**
- * Signup
- */
-exports.signup = function (req, res) {
-  // For security measurement we remove the roles from the req.body object
-  delete req.body.roles;
-
-  // Init user and add missing fields
-  var user = new User(req.body);
-  user.provider = 'local';
-  user.displayName = user.firstName + ' ' + user.lastName;
-
-  // Then save the user
-  user.save(function (err) {
-    if (err) {
-      return res.status(400).send({
-        message: errorHandler.getErrorMessage(err)
-      });
-    } else {
-      // Remove sensitive data before login
-      user.password = undefined;
-      user.salt = undefined;
-
-      req.login(user, function (err) {
-        if (err) {
-          res.status(400).send(err);
-        } else {
-          res.json(user);
-        }
-      });
-    }
-  });
-};
-
-/**
  * Signin after passport authentication
  */
 exports.signin = function (req, res, next) {

--- a/modules/users/server/controllers/users/users.verification.server.controller.js
+++ b/modules/users/server/controllers/users/users.verification.server.controller.js
@@ -1,0 +1,159 @@
+'use strict';
+
+/**
+ * Module dependencies
+ */
+var path = require('path'),
+  errorHandler = require(path.resolve('./modules/core/server/controllers/errors.server.controller')),
+  mongoose = require('mongoose'),
+  passport = require('passport'),
+  User = mongoose.model('User'),
+  config = require(path.resolve('./config/config')),
+  nev = require('email-verification')(mongoose);
+
+// Setup node-email-verification
+var config_nev = function () {
+
+  nev.configure({
+    tempUserCollection: 'tempusers_collection',
+    verificationURL: 'http://' + config.host + ':' + config.port + '/verification/${URL}',
+    persistentUserModel: User,
+
+    transportOptions: config.mailer.options,
+
+    // No templating support in node-email-verification yet
+    // https://github.com/whitef0x0/node-email-verification/issues/51
+    verifyMailOptions: {
+      from: config.mailer.from,
+      subject: 'Verify your ' + config.app.title + ' account',
+      html: '<p>Please verify your account by clicking <a href="${URL}">here</a>, or by copying and ' + 'pasting the following link into your browser:</p><p>${URL}</p>',
+      text: 'Please verify your account by clicking the following link, or by copying and pasting it into your browser: ${URL}'
+    },
+    confirmMailOptions: {
+      from: config.mailer.from,
+      subject: 'Account verified',
+      html: '<p>Your ' + config.app.title + ' account has been verified.</p>',
+      text: 'Your ' + config.app.title + ' account has been verified.'
+    },
+    shouldSendConfirmation: true,
+    verifySendMailCallback: function(err, info) {
+      if (err) {
+        throw err;
+      }
+    }
+  }, function(err, options) {
+    if (err) {
+      throw err;
+    }
+  });
+
+  nev.generateTempUserModel(User, function(err) {
+    if (err) {
+      throw err;
+    }
+  });
+
+};
+
+config_nev();
+
+exports.validateVerificationToken = function(req, res) {
+  nev.confirmTempUser(req.params.token, function(err, user) {
+    if (err) {
+      return res.status(500).send({ message: errorHandler.getErrorMessage(err) });
+    } else if (user) {
+      return res.status(200).send({ message: 'User successfully verified' });
+    } else {
+      // redirect to resend verification email
+      return res.status(400).send({ message: 'Verification token is invalid or has expired.' });
+    }
+  });
+};
+
+exports.resendVerificationEmail = function(req, res, next) {
+  nev.resendVerificationEmail(req.body.email, function(err, userFound) {
+    if (err) {
+      return res.status(500).send({ message: errorHandler.getErrorMessage(err) });
+    }
+
+    if (userFound) {
+      res.status(200).send({ message: 'Successfully re-sent verification email. Please check your email.' });
+    } else {
+      res.status(400).send({ message: 'Error: Email not found' });
+    }
+  });
+};
+
+/**
+ * Signup
+ */
+exports.signup = function (req, res) {
+  // For security measurement we remove the roles from the req.body object
+  delete req.body.roles;
+
+  // Init user and add missing fields
+  var user = new User(req.body);
+  user.provider = 'local';
+  user.displayName = user.firstName + ' ' + user.lastName;
+
+  // Only require email verification if configuration variable is set
+  if (config.verifyUserEmail) {
+
+    nev.createTempUser(user, function (err, existingPersistentUser, newTempUser) {
+      if (err) {
+        console.log(err);
+        return res.status(500).send({
+          message: errorHandler.getErrorMessage(err)
+        });
+      }
+
+      if (existingPersistentUser) {
+        if (err) {
+          return res.status(400).send({
+            message: 'Error: username already exists'
+          });
+        }
+      }
+
+      // New user created
+      if (newTempUser) {
+        var URL = newTempUser[nev.options.URLFieldName];
+        nev.sendVerificationEmail(user.email, URL, function (err, info) {
+          console.log(err);
+          if (err) {
+            return res.status(400).send({
+              message: 'Error: mail server down'
+            });
+          } else {
+            return res.status(200).send('An email has been sent to you. Please check it to verify your account.');
+          }
+        });
+      } else {
+        return res.status(400).send({ message: 'Error: User already waiting to be verified!' });
+      }
+    });
+
+  } else {
+    // Save the user directly to user model
+    user.save(function (err) {
+      if (err) {
+        return res.status(400).send({
+          message: errorHandler.getErrorMessage(err)
+        });
+      } else {
+        // Remove sensitive data before login
+        user.password = undefined;
+        user.salt = undefined;
+
+        req.login(user, function (err) {
+          if (err) {
+            res.status(400).send(err);
+          } else {
+            res.json(user);
+          }
+        });
+      }
+    });
+  }
+};
+

--- a/modules/users/server/routes/auth.server.routes.js
+++ b/modules/users/server/routes/auth.server.routes.js
@@ -19,6 +19,10 @@ module.exports = function (app) {
   app.route('/api/auth/signin').post(users.signin);
   app.route('/api/auth/signout').get(users.signout);
 
+  // Setting up the users account verification api
+  app.route('/api/auth/verify/:token').get(users.validateVerificationToken);
+  app.route('/api/auth/verify').post(users.resendVerificationEmail);
+
   // Setting the facebook oauth routes
   app.route('/api/auth/facebook').get(users.oauthCall('facebook', {
     scope: ['email']

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "connect-mongo": "~1.3.2",
     "cookie-parser": "~1.4.1",
     "crypto": "0.0.3",
+    "email-verification": "~0.4.5",
     "express": "~4.14.0",
     "express-hbs": "^1.0.2",
     "express-session": "~1.14.1",


### PR DESCRIPTION
feat(users): Email verification

This PR continues work that was started and abandoned in #1382, and was requested as far back as #94

I've got email verification up and running. You can check it out by starting https://github.com/djfarrelly/MailDev and using the following in `config.mailer.options`:
`port: 1025,
  ignoreTLS: true,`

There are a number of concerns that I want to bring up for discussion here:
@mleanos pointed out in the previous PR that the verification code needed to be much better organized. I fully agree with him, but found that due to the way node-email-verification works it is rather difficult to move any of it around.

As it is, I have put the signup functionality in `modules/users/server/controllers/users/users.verification.server.controller.js`. Taking this file piece by piece:
 - It is hard to move the node-email-verification configuration into for instance a config file, because it itself relies on several configuration values. Furthermore, the [docs](https://www.npmjs.com/package/email-verification) state all node-email-verification steps should be done in one central file - it's also not possible to use templates for the email HTML bodies at the moment.
 - I don't think it's right to move the API functions for validating and resending emails; refactoring them would become confusing.
 - I didn't want to do it but I moved the signup function into this controller. If you can see an easy way for it to remain in the users.authentication controller yet still capable of invoking the node-email-verification createTempUser functionality in another file, then please let me know. 
 - Right now a config variable decides whether a new user needs email verification or is saved the old way. You would want to easily switch email verification off during development. This led to the rather ugly hack of checking whether the response is a string or object post-sign up to work out whether verification was required or not.

In other words, it feels like the configuration, the verification API, and the creation of a user, should all be in different places, but in actual fact it's very hard to separate them. I can try to justify this by saying that `users.verification.server.controller.js` will simply handle signup... perhaps it should be called something else.

This is far from a final version, and I'm posting to ask for your thoughts on the issue and how this might proceed.