### PR TITLE
Deprecated $http success/error promise methods

### DIFF
--- a/modules/users/client/controllers/authentication.client.controller.js
+++ b/modules/users/client/controllers/authentication.client.controller.js
@@ -5,9 +5,9 @@
     .module('users')
     .controller('AuthenticationController', AuthenticationController);
 
-  AuthenticationController.$inject = ['$scope', '$state', '$http', '$location', '$window', 'Authentication', 'PasswordValidator'];
+  AuthenticationController.$inject = ['$scope', '$state', 'UsersService', '$location', '$window', 'Authentication', 'PasswordValidator'];
 
-  function AuthenticationController($scope, $state, $http, $location, $window, Authentication, PasswordValidator) {
+  function AuthenticationController($scope, $state, UsersService, $location, $window, Authentication, PasswordValidator) {
     var vm = this;
 
     vm.authentication = Authentication;
@@ -33,15 +33,9 @@
         return false;
       }
 
-      $http.post('/api/auth/signup', vm.credentials).success(function (response) {
-        // If successful we assign the response to the global user model
-        vm.authentication.user = response;
-
-        // And redirect to the previous or home page
-        $state.go($state.previous.state.name || 'home', $state.previous.params);
-      }).error(function (response) {
-        vm.error = response.message;
-      });
+      UsersService.userSignup(vm.credentials)
+        .then(onUserSignupSuccess)
+        .catch(onUserSignupError);
     }
 
     function signin(isValid) {
@@ -53,15 +47,9 @@
         return false;
       }
 
-      $http.post('/api/auth/signin', vm.credentials).success(function (response) {
-        // If successful we assign the response to the global user model
-        vm.authentication.user = response;
-
-        // And redirect to the previous or home page
-        $state.go($state.previous.state.name || 'home', $state.previous.params);
-      }).error(function (response) {
-        vm.error = response.message;
-      });
+      UsersService.userSignin(vm.credentials)
+        .then(onUserSigninSuccess)
+        .catch(onUserSigninError);
     }
 
     // OAuth provider request
@@ -72,6 +60,32 @@
 
       // Effectively call OAuth authentication route:
       $window.location.href = url;
+    }
+
+    // Authentication Callbacks
+
+    function onUserSignupSuccess(response) {
+      // If successful we assign the response to the global user model
+      vm.authentication.user = response;
+
+      // And redirect to the previous or home page
+      $state.go($state.previous.state.name || 'home', $state.previous.params);
+    }
+
+    function onUserSignupError(response) {
+      vm.error = response.data.message;
+    }
+
+    function onUserSigninSuccess(response) {
+      // If successful we assign the response to the global user model
+      vm.authentication.user = response;
+
+      // And redirect to the previous or home page
+      $state.go($state.previous.state.name || 'home', $state.previous.params);
+    }
+
+    function onUserSigninError(response) {
+      vm.error = response.data.message;
     }
   }
 }());

--- a/modules/users/client/controllers/settings/change-password.client.controller.js
+++ b/modules/users/client/controllers/settings/change-password.client.controller.js
@@ -5,9 +5,9 @@
     .module('users')
     .controller('ChangePasswordController', ChangePasswordController);
 
-  ChangePasswordController.$inject = ['$scope', '$http', 'Authentication', 'PasswordValidator'];
+  ChangePasswordController.$inject = ['$scope', '$http', 'Authentication', 'UsersService', 'PasswordValidator'];
 
-  function ChangePasswordController($scope, $http, Authentication, PasswordValidator) {
+  function ChangePasswordController($scope, $http, Authentication, UsersService, PasswordValidator) {
     var vm = this;
 
     vm.user = Authentication.user;
@@ -24,14 +24,20 @@
         return false;
       }
 
-      $http.post('/api/users/password', vm.passwordDetails).success(function (response) {
-        // If successful show success message and clear form
-        $scope.$broadcast('show-errors-reset', 'vm.passwordForm');
-        vm.success = true;
-        vm.passwordDetails = null;
-      }).error(function (response) {
-        vm.error = response.message;
-      });
+      UsersService.changePassword(vm.passwordDetails)
+        .then(onChangePasswordSuccess)
+        .catch(onChangePasswordError);
+    }
+
+    function onChangePasswordSuccess(response) {
+      // If successful show success message and clear form
+      $scope.$broadcast('show-errors-reset', 'vm.passwordForm');
+      vm.success = true;
+      vm.passwordDetails = null;
+    }
+
+    function onChangePasswordError(response) {
+      vm.error = response.data.message;
     }
   }
 }());

--- a/modules/users/client/controllers/settings/manage-social-accounts.client.controller.js
+++ b/modules/users/client/controllers/settings/manage-social-accounts.client.controller.js
@@ -5,9 +5,9 @@
     .module('users')
     .controller('SocialAccountsController', SocialAccountsController);
 
-  SocialAccountsController.$inject = ['$scope', '$http', 'Authentication'];
+  SocialAccountsController.$inject = ['$scope', 'UsersService', 'Authentication'];
 
-  function SocialAccountsController($scope, $http, Authentication) {
+  function SocialAccountsController($scope, UsersService, Authentication) {
     var vm = this;
 
     vm.user = Authentication.user;
@@ -29,17 +29,19 @@
     function removeUserSocialAccount(provider) {
       vm.success = vm.error = null;
 
-      $http.delete('/api/users/accounts', {
-        params: {
-          provider: provider
-        }
-      }).success(function (response) {
-        // If successful show success message and clear form
-        vm.success = true;
-        vm.user = Authentication.user = response;
-      }).error(function (response) {
-        vm.error = response.message;
-      });
+      UsersService.removeSocialAccount(provider)
+        .then(onRemoveSocialAccountSuccess)
+        .catch(onRemoveSocialAccountError);
+    }
+
+    function onRemoveSocialAccountSuccess(response) {
+      // If successful show success message and clear form
+      vm.success = true;
+      vm.user = Authentication.user = response;
+    }
+
+    function onRemoveSocialAccountError(response) {
+      vm.error = response.message;
     }
   }
 }());

--- a/modules/users/client/services/users.client.service.js
+++ b/modules/users/client/services/users.client.service.js
@@ -9,11 +9,65 @@
   UsersService.$inject = ['$resource'];
 
   function UsersService($resource) {
-    return $resource('api/users', {}, {
+    var Users = $resource('api/users', {}, {
       update: {
         method: 'PUT'
+      },
+      updatePassword: {
+        method: 'POST',
+        url: 'api/users/password'
+      },
+      deleteProvider: {
+        method: 'DELETE',
+        url: 'api/users/accounts',
+        params: {
+          provider: '@provider'
+        }
+      },
+      sendPasswordResetToken: {
+        method: 'POST',
+        url: 'api/auth/forgot'
+      },
+      resetPasswordWithToken: {
+        method: 'POST',
+        url: 'api/auth/reset/:token'
+      },
+      signup: {
+        method: 'POST',
+        url: 'api/auth/signup'
+      },
+      signin: {
+        method: 'POST',
+        url: 'api/auth/signin'
       }
     });
+
+    angular.extend(Users, {
+      changePassword: function (passwordDetails) {
+        return this.updatePassword(passwordDetails).$promise;
+      },
+      removeSocialAccount: function (provider) {
+        return this.deleteProvider({
+          provider: provider // api expects provider as a querystring parameter
+        }).$promise;
+      },
+      requestPasswordReset: function (credentials) {
+        return this.sendPasswordResetToken(credentials).$promise;
+      },
+      resetPassword: function (token, passwordDetails) {
+        return this.resetPasswordWithToken({
+          token: token // api expects token as a parameter (i.e. /:token)
+        }, passwordDetails).$promise;
+      },
+      userSignup: function (credentials) {
+        return this.signup(credentials).$promise;
+      },
+      userSignin: function (credentials) {
+        return this.signin(credentials).$promise;
+      }
+    });
+
+    return Users;
   }
 
   // TODO this should be Users service

--- a/modules/users/tests/client/authentication.client.controller.tests.js
+++ b/modules/users/tests/client/authentication.client.controller.tests.js
@@ -50,13 +50,13 @@
       describe('$scope.signin()', function () {
         it('should login with a correct user and password', function () {
           // Test expected GET request
-          $httpBackend.when('POST', '/api/auth/signin').respond(200, 'Fred');
+          $httpBackend.when('POST', 'api/auth/signin').respond(200, { username: 'Fred' });
 
           scope.vm.signin(true);
           $httpBackend.flush();
 
           // Test scope value
-          expect(scope.vm.authentication.user).toEqual('Fred');
+          expect(scope.vm.authentication.user.username).toEqual('Fred');
           expect($location.url()).toEqual('/');
         });
 
@@ -75,7 +75,7 @@
             spyOn($state, 'go');
 
             // Test expected GET request
-            $httpBackend.when('POST', '/api/auth/signin').respond(200, 'Fred');
+            $httpBackend.when('POST', 'api/auth/signin').respond(200, 'Fred');
 
             scope.vm.signin(true);
             $httpBackend.flush();
@@ -88,7 +88,7 @@
 
         it('should fail to log in with nothing', function () {
           // Test expected POST request
-          $httpBackend.expectPOST('/api/auth/signin').respond(400, {
+          $httpBackend.expectPOST('api/auth/signin').respond(400, {
             'message': 'Missing credentials'
           });
 
@@ -101,11 +101,11 @@
 
         it('should fail to log in with wrong credentials', function () {
           // Foo/Bar combo assumed to not exist
-          scope.vm.authentication.user = 'Foo';
+          scope.vm.authentication.user = { usersname: 'Foo' };
           scope.vm.credentials = 'Bar';
 
           // Test expected POST request
-          $httpBackend.expectPOST('/api/auth/signin').respond(400, {
+          $httpBackend.expectPOST('api/auth/signin').respond(400, {
             'message': 'Unknown user'
           });
 
@@ -121,20 +121,20 @@
         it('should register with correct data', function () {
           // Test expected GET request
           scope.vm.authentication.user = 'Fred';
-          $httpBackend.when('POST', '/api/auth/signup').respond(200, 'Fred');
+          $httpBackend.when('POST', 'api/auth/signup').respond(200, { username: 'Fred' });
 
           scope.vm.signup(true);
           $httpBackend.flush();
 
           // test scope value
-          expect(scope.vm.authentication.user).toBe('Fred');
+          expect(scope.vm.authentication.user.username).toBe('Fred');
           expect(scope.vm.error).toEqual(null);
           expect($location.url()).toBe('/');
         });
 
         it('should fail to register with duplicate Username', function () {
           // Test expected POST request
-          $httpBackend.when('POST', '/api/auth/signup').respond(400, {
+          $httpBackend.when('POST', 'api/auth/signup').respond(400, {
             'message': 'Username already exists'
           });
 

--- a/modules/users/tests/client/password.client.controller.tests.js
+++ b/modules/users/tests/client/password.client.controller.tests.js
@@ -29,7 +29,7 @@
     beforeEach(module(ApplicationConfiguration.applicationModuleName));
 
     describe('Logged in user', function() {
-      beforeEach(inject(function($controller, $rootScope, _Authentication_, _$stateParams_, _$httpBackend_, _$location_) {
+      beforeEach(inject(function($controller, $rootScope, _UsersService_, _Authentication_, _$stateParams_, _$httpBackend_, _$location_) {
         // Set a new global scope
         scope = $rootScope.$new();
 
@@ -100,7 +100,7 @@
         describe('POST error', function() {
           var errorMessage = 'No account with that username has been found';
           beforeEach(function() {
-            $httpBackend.when('POST', '/api/auth/forgot', credentials).respond(400, {
+            $httpBackend.when('POST', 'api/auth/forgot', credentials).respond(400, {
               'message': errorMessage
             });
 
@@ -120,7 +120,7 @@
         describe('POST success', function() {
           var successMessage = 'An email has been sent to the provided email with further instructions.';
           beforeEach(function() {
-            $httpBackend.when('POST', '/api/auth/forgot', credentials).respond({
+            $httpBackend.when('POST', 'api/auth/forgot', credentials).respond({
               'message': successMessage
             });
 
@@ -159,7 +159,7 @@
 
         it('POST error should set scope.error to response message', function() {
           var errorMessage = 'Passwords do not match';
-          $httpBackend.when('POST', '/api/auth/reset/' + token, passwordDetails).respond(400, {
+          $httpBackend.when('POST', 'api/auth/reset/' + token, passwordDetails).respond(400, {
             'message': errorMessage
           });
 
@@ -174,7 +174,7 @@
             username: 'test'
           };
           beforeEach(function() {
-            $httpBackend.when('POST', '/api/auth/reset/' + token, passwordDetails).respond(user);
+            $httpBackend.when('POST', 'api/auth/reset/' + token, passwordDetails).respond(user);
 
             scope.vm.resetUserPassword(true);
             $httpBackend.flush();
@@ -185,7 +185,7 @@
           });
 
           it('should attach user profile', function() {
-            expect(scope.vm.authentication.user).toEqual(user);
+            expect(scope.vm.authentication.user.username).toEqual(user.username);
           });
 
           it('should redirect to password reset success view', function() {


### PR DESCRIPTION
Replaces the $http service calls with promise based methods of the client-side UsersService for the following:
  Users Change Password
  Users Manage Social Accounts
  Users Password Forgot
  Users Password Reset
  Users Signup
  Users Signin

Modifies tests to reflect changes.

Closes #1479
