### PR TITLE
fix(core): Add custom 400 and 404 error messages

### DIFF
--- a/modules/core/client/config/core.client.route-filter.js
+++ b/modules/core/client/config/core.client.route-filter.js
@@ -25,7 +25,7 @@
 
         if (!allowed) {
           event.preventDefault();
-          if (Authentication.user !== null && typeof Authentication.user === 'object') {
+          if (Authentication.user !== undefined && typeof Authentication.user === 'object') {
             $state.transitionTo('forbidden');
           } else {
             $state.go('authentication.signin').then(function () {

--- a/modules/core/client/config/core.client.route-filter.js
+++ b/modules/core/client/config/core.client.route-filter.js
@@ -25,7 +25,7 @@
 
         if (!allowed) {
           event.preventDefault();
-          if (Authentication.user !== undefined && typeof Authentication.user === 'object') {
+          if (Authentication.user !== null && typeof Authentication.user === 'object') {
             $state.transitionTo('forbidden');
           } else {
             $state.go('authentication.signin').then(function () {

--- a/modules/core/client/config/core.client.routes.js
+++ b/modules/core/client/config/core.client.routes.js
@@ -21,7 +21,9 @@
 
     // Redirect to 404 when route not found
     $urlRouterProvider.otherwise(function ($injector, $location) {
-      $injector.get('$state').transitionTo('not-found');
+      $injector.get('$state').transitionTo('not-found', null, {
+        location: false
+      });
     });
 
     $stateProvider

--- a/modules/core/client/config/core.client.routes.js
+++ b/modules/core/client/config/core.client.routes.js
@@ -21,9 +21,7 @@
 
     // Redirect to 404 when route not found
     $urlRouterProvider.otherwise(function ($injector, $location) {
-      $injector.get('$state').transitionTo('not-found', null, {
-        location: false
-      });
+      $injector.get('$state').transitionTo('not-found');
     });
 
     $stateProvider
@@ -36,17 +34,31 @@
       .state('not-found', {
         url: '/not-found',
         templateUrl: 'modules/core/client/views/404.client.view.html',
+        controller: 'ErrorController',
+        controllerAs: 'vm',
+        params: {
+          message: function($stateParams) {
+            return $stateParams.message;
+          }
+        },
         data: {
           ignoreState: true,
-          pageTitle: 'Not-Found'
+          pageTitle: 'Not Found'
         }
       })
       .state('bad-request', {
         url: '/bad-request',
         templateUrl: 'modules/core/client/views/400.client.view.html',
+        controller: 'ErrorController',
+        controllerAs: 'vm',
+        params: {
+          message: function($stateParams) {
+            return $stateParams.message;
+          }
+        },
         data: {
           ignoreState: true,
-          pageTitle: 'Bad-Request'
+          pageTitle: 'Bad Request'
         }
       })
       .state('forbidden', {

--- a/modules/core/client/controllers/error.client.controller.js
+++ b/modules/core/client/controllers/error.client.controller.js
@@ -1,0 +1,18 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('core')
+    .controller('ErrorController', ErrorController);
+
+  ErrorController.$inject = ['$stateParams'];
+
+  function ErrorController($stateParams) {
+    var vm = this;
+    vm.errorMessage = null;
+
+    // Display custom message if it was set
+    if ($stateParams.message) vm.errorMessage = $stateParams.message;
+  }
+}());
+

--- a/modules/core/client/services/interceptors/auth-interceptor.client.service.js
+++ b/modules/core/client/services/interceptors/auth-interceptor.client.service.js
@@ -17,6 +17,9 @@
     function responseError(rejection) {
       if (!rejection.config.ignoreAuthModule) {
         switch (rejection.status) {
+          case 400:
+            $injector.get('$state').go('bad-request', { message: rejection.data.message });
+            break;
           case 401:
             // Deauthenticate the global user
             Authentication.user = null;
@@ -24,6 +27,9 @@
             break;
           case 403:
             $injector.get('$state').transitionTo('forbidden');
+            break;
+          case 404:
+            $injector.get('$state').go('not-found', { message: rejection.data.message });
             break;
         }
       }

--- a/modules/core/client/views/400.client.view.html
+++ b/modules/core/client/views/400.client.view.html
@@ -1,4 +1,6 @@
-<h1>Bad Request</h1>
+<div class="page-header">
+  <h1>Bad Request</h1>
+</div>
 <div class="alert alert-danger" role="alert">
   <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
   <span class="sr-only">Error:</span>

--- a/modules/core/client/views/400.client.view.html
+++ b/modules/core/client/views/400.client.view.html
@@ -2,5 +2,6 @@
 <div class="alert alert-danger" role="alert">
   <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
   <span class="sr-only">Error:</span>
-  You made a bad request
+  <span ng-if="vm.errorMessage" ng-bind="vm.errorMessage"></span>
+  <span ng-if="!vm.errorMessage">You made a bad request</span>
 </div>

--- a/modules/core/client/views/403.client.view.html
+++ b/modules/core/client/views/403.client.view.html
@@ -1,4 +1,6 @@
-<h1>Forbidden</h1>
+<div class="page-header">
+  <h1>Forbidden</h1>
+</div>
 <div class="alert alert-danger" role="alert">
   <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
   <span class="sr-only">Error:</span>

--- a/modules/core/client/views/404.client.view.html
+++ b/modules/core/client/views/404.client.view.html
@@ -1,5 +1,6 @@
 <h1>Page Not Found</h1>
 <div class="alert alert-danger" role="alert">
   <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-  <span class="sr-only">Error:</span> Page Not Found
+  <span ng-if="vm.errorMessage" ng-bind="vm.errorMessage"></span>
+  <span ng-if="!vm.errorMessage">Page Not Found</span>
 </div>

--- a/modules/core/client/views/404.client.view.html
+++ b/modules/core/client/views/404.client.view.html
@@ -1,4 +1,6 @@
-<h1>Page Not Found</h1>
+<div class="page-header">
+  <h1>Page Not Found</h1>
+</div>
 <div class="alert alert-danger" role="alert">
   <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
   <span ng-if="vm.errorMessage" ng-bind="vm.errorMessage"></span>


### PR DESCRIPTION
fix(core): Add custom 400 and 404 error messages

Fixes #1504 

--------

One remaining problem is that ideally, the bad URL should remain the same (i.e. /articles/noarticlehere rather than /not-found) and still display an error message. I was able to get halfway there by deleting the url property from the error routes, but then you have another issue where the valid page before getting the error cannot be reached in the browser history. The 404 article page is intercepted _before_ it is displayed, so then the browser would think that the page before that and the error page were the same entity, rather than the bad article page and the error. But that's for another PR.