### PR TITLE
feat(core): Add error handler for failed requests

### DIFF
--- a/modules/core/client/services/interceptors/auth-interceptor.client.service.js
+++ b/modules/core/client/services/interceptors/auth-interceptor.client.service.js
@@ -31,6 +31,10 @@
           case 404:
             $injector.get('$state').go('not-found', { message: rejection.data.message });
             break;
+          case -1:  // Handle error if no response from server(Network Lost or Server not responding)
+            var Notification = $injector.get('Notification');
+            Notification.error({ message: 'No response received from server. Please try again later.', title: 'Error processing request!', delay: 5000 });
+            break;
         }
       }
       // otherwise, default behaviour

--- a/modules/core/tests/client/interceptors/auth-interceptor.client.tests.js
+++ b/modules/core/tests/client/interceptors/auth-interceptor.client.tests.js
@@ -62,5 +62,22 @@
         expect($state.transitionTo).toHaveBeenCalledWith('authentication.signin');
       });
     });
+
+    describe('Unresponsive Interceptor', function() {
+      var Notification;
+      beforeEach(inject(function(_Notification_) {
+        Notification = _Notification_;
+        spyOn(Notification, 'error');
+      }));
+      it('should show error Notification', function () {
+        var response = {
+          status: -1,
+          config: {}
+        };
+        var promise = authInterceptor.responseError(response);
+        expect($q.reject).toHaveBeenCalled();
+        expect(Notification.error).toHaveBeenCalledWith({ message: 'No response received from server. Please try again later.', title: 'Error processing request!', delay: 5000 });
+      });
+    });
   });
 }());


### PR DESCRIPTION
feat(core): Add error handler for failed requests

Add error handle for failed requests(no response from server)
Using Notification.error to show error message
Added test for the notification in Auth Interceptor

Fixes #1556