### PR TITLE
feat: users : Abstract OAuth URL's

### DIFF
--- a/modules/users/server/config/strategies/facebook.js
+++ b/modules/users/server/config/strategies/facebook.js
@@ -14,7 +14,8 @@ module.exports = function (config) {
     clientSecret: config.facebook.clientSecret,
     callbackURL: config.facebook.callbackURL,
     profileFields: ['id', 'name', 'displayName', 'emails', 'photos'],
-    passReqToCallback: true
+    passReqToCallback: true,
+    scope: ['email']
   },
   function (req, accessToken, refreshToken, profile, done) {
     // Set the provider data and include tokens

--- a/modules/users/server/config/strategies/google.js
+++ b/modules/users/server/config/strategies/google.js
@@ -13,8 +13,11 @@ module.exports = function (config) {
     clientID: config.google.clientID,
     clientSecret: config.google.clientSecret,
     callbackURL: config.google.callbackURL,
-    passReqToCallback: true
-  },
+    passReqToCallback: true,
+    scope:  [ 'https://www.googleapis.com/auth/userinfo.profile',
+              'https://www.googleapis.com/auth/userinfo.email'
+            ]
+    },
   function (req, accessToken, refreshToken, profile, done) {
     // Set the provider data and include tokens
     var providerData = profile._json;

--- a/modules/users/server/config/strategies/linkedin.js
+++ b/modules/users/server/config/strategies/linkedin.js
@@ -14,7 +14,11 @@ module.exports = function (config) {
     consumerSecret: config.linkedin.clientSecret,
     callbackURL: config.linkedin.callbackURL,
     passReqToCallback: true,
-    profileFields: ['id', 'first-name', 'last-name', 'email-address', 'picture-url']
+    profileFields: ['id', 'first-name', 'last-name', 'email-address', 'picture-url'],
+    scope: [
+      'r_basicprofile',
+      'r_emailaddress'
+    ]
   },
   function (req, accessToken, refreshToken, profile, done) {
     // Set the provider data and include tokens

--- a/modules/users/server/controllers/users/users.authentication.server.controller.js
+++ b/modules/users/server/controllers/users/users.authentication.server.controller.js
@@ -83,18 +83,17 @@ exports.signout = function (req, res) {
 /**
  * OAuth provider call
  */
-exports.oauthCall = function (strategy, scope) {
-  return function (req, res, next) {
+exports.oauthCall = function (req, res, next) {
+    var strategy = req.params.strategy;
     // Authenticate
-    passport.authenticate(strategy, scope)(req, res, next);
+    passport.authenticate(strategy)(req, res, next);
   };
-};
 
 /**
  * OAuth callback
  */
-exports.oauthCallback = function (strategy) {
-  return function (req, res, next) {
+exports.oauthCallback = function (req, res, next) {
+    var strategy = req.params.strategy;
 
     // info.redirect_to contains inteded redirect path
     passport.authenticate(strategy, function (err, user, info) {
@@ -112,7 +111,6 @@ exports.oauthCallback = function (strategy) {
         return res.redirect(info.redirect_to || '/');
       });
     })(req, res, next);
-  };
 };
 
 /**

--- a/modules/users/server/routes/auth.server.routes.js
+++ b/modules/users/server/routes/auth.server.routes.js
@@ -19,39 +19,8 @@ module.exports = function (app) {
   app.route('/api/auth/signin').post(users.signin);
   app.route('/api/auth/signout').get(users.signout);
 
-  // Setting the facebook oauth routes
-  app.route('/api/auth/facebook').get(users.oauthCall('facebook', {
-    scope: ['email']
-  }));
-  app.route('/api/auth/facebook/callback').get(users.oauthCallback('facebook'));
+  // Setting the oauth routes
+  app.route('/api/auth/:strategy').get(users.oauthCall);
+  app.route('/api/auth/:strategy/callback').get(users.oauthCallback);
 
-  // Setting the twitter oauth routes
-  app.route('/api/auth/twitter').get(users.oauthCall('twitter'));
-  app.route('/api/auth/twitter/callback').get(users.oauthCallback('twitter'));
-
-  // Setting the google oauth routes
-  app.route('/api/auth/google').get(users.oauthCall('google', {
-    scope: [
-      'https://www.googleapis.com/auth/userinfo.profile',
-      'https://www.googleapis.com/auth/userinfo.email'
-    ]
-  }));
-  app.route('/api/auth/google/callback').get(users.oauthCallback('google'));
-
-  // Setting the linkedin oauth routes
-  app.route('/api/auth/linkedin').get(users.oauthCall('linkedin', {
-    scope: [
-      'r_basicprofile',
-      'r_emailaddress'
-    ]
-  }));
-  app.route('/api/auth/linkedin/callback').get(users.oauthCallback('linkedin'));
-
-  // Setting the github oauth routes
-  app.route('/api/auth/github').get(users.oauthCall('github'));
-  app.route('/api/auth/github/callback').get(users.oauthCallback('github'));
-
-  // Setting the paypal oauth routes
-  app.route('/api/auth/paypal').get(users.oauthCall('paypal'));
-  app.route('/api/auth/paypal/callback').get(users.oauthCallback('paypal'));
 };


### PR DESCRIPTION
feat: users : Abstract OAuth URL's & Move Scope to Strategy File

Changes the server routes for OAuth to utilize a request parameter so there is one pair of routes for all OAuth requests, verses one for every strategy (Twitter, Google, etc). To support this all scope definitions were moved from the routes to the actual strategy files. This keeps the strategy definitions isolated to the modules/users/server/config/strategies, which makes it much simpler to maintain and add new strategies.
