### PR TITLE
Node engine updates and package.json additional scripts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,6 +51,7 @@ module.exports = {
   },
   env: {
     node: true,
+    es6: true,
     browser: true,
     jasmine: true,
     mocha: true,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "update": "npm update && npm prune && bower install --allow-root && bower prune --allow-root",
     "clean": "rm -rf node_modules/ public/lib/",
-    "reinstall": "npm run clean && npm install",
+    "reinstall": "npm cache clean && npm run clean && npm install",
     "start": "gulp",
     "start:prod": "gulp prod",
     "start:debug": "node-debug --web-host 0.0.0.0 server.js & gulp debug",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "url": "https://github.com/meanjs/mean.git"
   },
   "engines": {
-    "node": ">=0.12.0",
-    "npm": ">=2.0.0"
+    "node": ">=4.6.0",
+    "npm": ">=3.10.8"
   },
   "scripts": {
     "update": "npm update && npm prune && bower install --allow-root && bower prune --allow-root",
+    "clean": "rm -rf node_modules/ public/lib/",
+    "reinstall": "npm run clean && npm install",
     "start": "gulp",
     "start:prod": "gulp prod",
     "start:debug": "node-debug --web-host 0.0.0.0 server.js & gulp debug",


### PR DESCRIPTION
This PR supersedes https://github.com/meanjs/mean/pull/1414 and updates core node package engine (including es5 support for eslint configuration), as well as adding a `cleanup` and `reinstall` npm shortcut scripts.