### PR TITLE
fix(config): Default config dangling comma

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -8,7 +8,7 @@ module.exports = {
     googleAnalyticsTrackingID: process.env.GOOGLE_ANALYTICS_TRACKING_ID || 'GOOGLE_ANALYTICS_TRACKING_ID'
   },
   db: {
-    promise: global.Promise,
+    promise: global.Promise
   },
   port: process.env.PORT || 3000,
   host: process.env.HOST || '0.0.0.0',


### PR DESCRIPTION
Removes the dangling comma from the default configuration db.promise
setting. This was causing a lint error.