### PR TITLE
Dynamic Loading of OAuth providers based On if they're in the config.

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -30,7 +30,13 @@ module.exports = {
   facebook: {
     clientID: process.env.FACEBOOK_ID || 'APP_ID',
     clientSecret: process.env.FACEBOOK_SECRET || 'APP_SECRET',
-    callbackURL: '/api/auth/facebook/callback'
+    callbackURL: '/api/auth/facebook/callback',
+    viewData : {
+      initURL : '/api/auth/facebook',
+      imageSRC : '/modules/users/client/img/buttons/facebook.png',
+      altText : 'Login with Facebook Today!',
+      name : 'Facebook'
+    }
   },
   twitter: {
     clientID: process.env.TWITTER_KEY || 'CONSUMER_KEY',

--- a/modules/users/client/controllers/authentication.client.controller.js
+++ b/modules/users/client/controllers/authentication.client.controller.js
@@ -5,9 +5,15 @@
     .module('users')
     .controller('AuthenticationController', AuthenticationController);
 
-  AuthenticationController.$inject = ['$scope', '$state', 'UsersService', '$location', '$window', 'Authentication', 'PasswordValidator', 'Notification'];
+  AuthenticationController.$inject = ['$scope', '$state', '$http', 'UsersService', '$location', '$window', 'Authentication', 'PasswordValidator', 'Notification'];
 
-  function AuthenticationController($scope, $state, UsersService, $location, $window, Authentication, PasswordValidator, Notification) {
+  function AuthenticationController($scope, $state, $http, UsersService, $location, $window, Authentication, PasswordValidator, Notification) {
+    //Populate The Strategies
+    $http.get('/api/auth/strategies').then(function(response) {
+        $scope.strategies = response.data;
+        $scope.showSocial = (Object.keys($scope.strategies).length > 0) ? true : false;
+    });
+
     var vm = this;
 
     vm.authentication = Authentication;

--- a/modules/users/client/views/authentication/authentication.client.view.html
+++ b/modules/users/client/views/authentication/authentication.client.view.html
@@ -1,12 +1,7 @@
 <section class="row">
-  <h3 class="col-md-12 text-center">Sign in using your social accounts</h3>
+  <h3 class="col-md-12 text-center" ng-show="showSocial">Sign in using your social accounts</h3>
   <div class="col-md-12 text-center">
-    <div class="social-account-container social-button"><a class="btn"><img class="img-responsive" ng-click="vm.callOauthProvider('/api/auth/facebook')" ng-src="/modules/users/client/img/buttons/facebook.png"></a></div>
-    <div class="social-account-container social-button"><a class="btn"><img class="img-responsive" ng-click="vm.callOauthProvider('/api/auth/twitter')" ng-src="/modules/users/client/img/buttons/twitter.png"></a></div>
-    <div class="social-account-container social-button"><a class="btn"><img class="img-responsive" ng-click="vm.callOauthProvider('/api/auth/google')" ng-src="/modules/users/client/img/buttons/google.png"></a></div>
-    <div class="social-account-container social-button"><a class="btn"><img class="img-responsive" ng-click="vm.callOauthProvider('/api/auth/linkedin')" ng-src="/modules/users/client/img/buttons/linkedin.png"></a></div>
-    <div class="social-account-container social-button"><a class="btn"><img class="img-responsive" ng-click="vm.callOauthProvider('/api/auth/github')" ng-src="/modules/users/client/img/buttons/github.png"></a></div>
-    <div class="social-account-container social-button"><a class="btn"><img class="img-responsive" ng-click="vm.callOauthProvider('/api/auth/paypal')"  ng-src="/modules/users/client/img/buttons/paypal.png"></a></div>
+    <div class="social-account-container social-button" ng-repeat="(strategyName, strategy) in strategies"><a class="btn"><img class="img-responsive" ng-click="vm.callOauthProvider(strategy.initURL)" ng-src="{{strategy.imageSRC}}" alt="{{strategy.altText}}"></a></div>
   </div>
   <div ui-view></div>
 </section>

--- a/modules/users/server/routes/auth.server.routes.js
+++ b/modules/users/server/routes/auth.server.routes.js
@@ -19,12 +19,15 @@ module.exports = function (app) {
   app.route('/api/auth/signin').post(users.signin);
   app.route('/api/auth/signout').get(users.signout);
 
+  //Get a list of available strategies
+  app.route('/api/auth/strategies').get(users.getAuthProviders);
+
   // Setting the facebook oauth routes
   app.route('/api/auth/facebook').get(users.oauthCall('facebook', {
     scope: ['email']
   }));
   app.route('/api/auth/facebook/callback').get(users.oauthCallback('facebook'));
-
+  
   // Setting the twitter oauth routes
   app.route('/api/auth/twitter').get(users.oauthCall('twitter'));
   app.route('/api/auth/twitter/callback').get(users.oauthCallback('twitter'));


### PR DESCRIPTION
## feat: users - Dynamic OAuth / Social Providers

This update adds a new REST call which pulls back a list of the available strategies which have settings defined within the env config (config\env). This REST end-point is then called from the user AuthenticationController in order to dynamically list strategies within authentication.client.view.html utilizing ng-repeat. The display attributes (Image, alt-text, oauth url) have default values based on the strategy name, but this can also be overridden in the environment configuration. 

With this pull request, and my pull request updating the router for Oauth calls; its now possible to add a new Oauth provider simply by adding a strategy.js, and adding the needed config items to the environment config. Everything else is dynamic. There is longer a need to update four places.