### PR TITLE
fix(core): fix twitter meta tags

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -33,6 +33,7 @@ module.exports = {
     callbackURL: '/api/auth/facebook/callback'
   },
   twitter: {
+    username: '@TWITTER_USERNAME',
     clientID: process.env.TWITTER_KEY || 'CONSUMER_KEY',
     clientSecret: process.env.TWITTER_SECRET || 'CONSUMER_SECRET',
     callbackURL: '/api/auth/twitter/callback'

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -53,6 +53,7 @@ module.exports = {
     callbackURL: '/api/auth/facebook/callback'
   },
   twitter: {
+    username: '@TWITTER_USERNAME',
     clientID: process.env.TWITTER_KEY || 'CONSUMER_KEY',
     clientSecret: process.env.TWITTER_SECRET || 'CONSUMER_SECRET',
     callbackURL: '/api/auth/twitter/callback'

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -34,6 +34,7 @@ module.exports = {
     callbackURL: '/api/auth/facebook/callback'
   },
   twitter: {
+    username: '@TWITTER_USERNAME',
     clientID: process.env.TWITTER_KEY || 'CONSUMER_KEY',
     clientSecret: process.env.TWITTER_SECRET || 'CONSUMER_SECRET',
     callbackURL: '/api/auth/twitter/callback'

--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -34,6 +34,7 @@ module.exports.initLocalVariables = function (app) {
   app.locals.keywords = config.app.keywords;
   app.locals.googleAnalyticsTrackingID = config.app.googleAnalyticsTrackingID;
   app.locals.facebookAppId = config.facebook.clientID;
+  app.locals.twitterUsername = config.twitter.username;
   app.locals.jsFiles = config.files.client.js;
   app.locals.cssFiles = config.files.client.css;
   app.locals.livereload = config.livereload;

--- a/modules/core/server/views/layout.server.view.html
+++ b/modules/core/server/views/layout.server.view.html
@@ -22,9 +22,10 @@
   <meta property="og:type" content="website">
 
   <!-- Twitter META -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="{{twitterUsername}}">
   <meta name="twitter:title" content="{{title}}">
   <meta name="twitter:description" content="{{description}}">
-  <meta name="twitter:url" content="{{url}}">
   <meta name="twitter:image" content="{{logo}}">
 
   <!-- Fav Icon -->


### PR DESCRIPTION
fix(core): fix twitter meta tags

I believe the Twitter meta tags are outdated and this PR fixes them.
Taking into account the current MEAN.js tags and the Twitter docs, the most similar feature I found
is the Twitter Summary Card (https://dev.twitter.com/cards/types/summary), which requires 2 tags that currently do not exist (twitter:card and twitter:site) and there's another one already implemented in MEAN.js which is not referenced in Twitter docs (twitter:url).