### PR TITLE
feat(build): Ignore compiled sass/less files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ config/env/local.js
 config/env/local-*.js
 *.pem
 
+# Compiled less and sass files
+# ============================
+modules/*/client/scss/*.css
+modules/*/client/less/*.css
+
 # Ignoring MEAN.JS's gh-pages branch for documenation
 _site/
 

--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -31,7 +31,7 @@ module.exports = {
       tests: ['public/lib/angular-mocks/angular-mocks.js']
     },
     css: [
-      'modules/*/client/css/*.css'
+      'modules/*/client/{css,less,scss}/*.css'
     ],
     less: [
       'modules/*/client/less/*.less'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -169,9 +169,6 @@ gulp.task('sass', function () {
   return gulp.src(defaultAssets.client.sass)
     .pipe(plugins.sass())
     .pipe(plugins.autoprefixer())
-    .pipe(plugins.rename(function (file) {
-      file.dirname = file.dirname.replace(path.sep + 'scss', path.sep + 'css');
-    }))
     .pipe(gulp.dest('./modules/'));
 });
 
@@ -180,9 +177,6 @@ gulp.task('less', function () {
   return gulp.src(defaultAssets.client.less)
     .pipe(plugins.less())
     .pipe(plugins.autoprefixer())
-    .pipe(plugins.rename(function (file) {
-      file.dirname = file.dirname.replace(path.sep + 'less', path.sep + 'css');
-    }))
     .pipe(gulp.dest('./modules/'));
 });
 


### PR DESCRIPTION
Compiling `sass/less` files to `<module>/client/css` directory makes it difficult to differentiate between compiled and raw css files.

By compiling them to appropriate directories, compiled files can be easily ignored.