### PR TITLE
feat(ci): Test for NodeJS v7 (allow failure)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ node_js:
   - 4
   - 5
   - 6
+  - 7
+matrix:
+  allow_failures:
+    - node_js: 7
 os:
   - linux
   - centos


### PR DESCRIPTION
NodeJS v7 is out: https://nodejs.org/en/blog/release/v7.0.0/
