### PR TITLE
fix(config): Default env config lint error

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -43,8 +43,8 @@ module.exports = {
   logo: 'modules/core/client/img/brand/logo.png',
   favicon: 'modules/core/client/img/brand/favicon.ico',
   illegalUsernames: ['meanjs', 'administrator', 'password', 'admin', 'user',
-                   'unknown', 'anonymous', 'null', 'undefined', 'api'
-                  ],
+    'unknown', 'anonymous', 'null', 'undefined', 'api'
+  ],
   uploads: {
     profileUpload: {
       dest: './modules/users/client/img/profile/uploads/', // Profile upload destination path


### PR DESCRIPTION
Fixes linting errors thrown from incorrect spacing in the default environment config. Incorrect spacing at the `illegalUsernames` config setting.
