### PR TITLE
Incorrect production assets

### DIFF
--- a/config/assets/production.js
+++ b/config/assets/production.js
@@ -7,10 +7,9 @@ module.exports = {
     lib: {
       css: [
         // bower:css
+        'public/lib/angular-ui-notification/dist/angular-ui-notification.min.css',
         'public/lib/bootstrap/dist/css/bootstrap.min.css',
         'public/lib/bootstrap/dist/css/bootstrap-theme.min.css',
-        'public/lib/ng-img-crop/compile/minified/ng-img-crop.css',
-        'public/lib/angular-ui-notification/dist/angular-ui-notification.min.css'
         // endbower
       ],
       js: [
@@ -24,7 +23,6 @@ module.exports = {
         'public/lib/angular-ui-notification/dist/angular-ui-notification.min.js',
         'public/lib/angular-ui-router/release/angular-ui-router.min.js',
         'public/lib/ng-file-upload/ng-file-upload.min.js',
-        'public/lib/ng-img-crop/compile/minified/ng-img-crop.js',
         'public/lib/owasp-password-strength-test/owasp-password-strength-test.js',
         // endbower
       ]


### PR DESCRIPTION
Removed the ng-img-crop references from the production assets
configuration, since the library has been removed from the project.

Also, re-ordered the CSS section to be in alphabetical order.
