### PR TITLE
feat(server): Add warning if using an unsupported version of Node

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -82,7 +82,7 @@ var validateNodeJsVersion = function (config) {
  * Validate config.domain is set
  */
 var validateDomainIsSet = function (config) {
-  if (!config.domain) {
+  if (!config.domain && process.env.NODE_ENV === 'production') {
     console.log(chalk.red('+ Important warning: config.domain is empty. It should be set to the fully qualified domain of the app.'));
   }
 };

--- a/config/config.js
+++ b/config/config.js
@@ -7,7 +7,8 @@ var _ = require('lodash'),
   chalk = require('chalk'),
   glob = require('glob'),
   fs = require('fs'),
-  path = require('path');
+  path = require('path'),
+  semver = require('semver');
 
 /**
  * Get files by glob patterns
@@ -68,7 +69,17 @@ var validateEnvironmentVariable = function () {
   console.log(chalk.white(''));
 };
 
-/** Validate config.domain is set
+/**
+ * Validate user is running supported Node.js version
+ */
+var validateNodeJsVersion = function (config) {
+  if (!semver.satisfies(process.version, config.meanjs.engines.node)) {
+    console.log(chalk.red('+ Important warning: your version of Node (' + process.version.substr(1) + ') is unsupported by MEAN.js. Please use a version that satisfies the following requirements: ' + config.meanjs.engines.node + ', as specified in the package.json file.'));
+  }
+};
+
+/**
+ * Validate config.domain is set
  */
 var validateDomainIsSet = function (config) {
   if (!config.domain) {
@@ -172,6 +183,7 @@ var initGlobalConfigFiles = function (config, assets) {
  * Initialize global configuration
  */
 var initGlobalConfig = function () {
+
   // Validate NODE_ENV existence
   validateEnvironmentVariable();
 
@@ -211,6 +223,9 @@ var initGlobalConfig = function () {
 
   // Validate session secret
   validateSessionSecret(config);
+
+  // Print a warning if using unsupported version of Node.js
+  validateNodeJsVersion(config);
 
   // Print a warning if config.domain is not set
   validateDomainIsSet(config);

--- a/config/lib/app.js
+++ b/config/lib/app.js
@@ -47,6 +47,7 @@ module.exports.start = function start(callback) {
       console.log(chalk.green('App version:     ' + config.meanjs.version));
       if (config.meanjs['meanjs-version'])
         console.log(chalk.green('MEAN.JS version: ' + config.meanjs['meanjs-version']));
+      console.log(chalk.green('Node version:    ' + process.version.substr(1)));
       console.log('--');
 
       if (callback) callback(app, db, config);


### PR DESCRIPTION
As suggested by @codydaig at #1655. A lot of the issues here recently have been raised by people simply running the wrong versions of Node, and while the majority are errors during the `npm install` step, sometimes the user will inadvertently manage to run MEAN with the wrong Node version and encounter weird errors... hopefully this will prevent that.