### PR TITLE
[v2] - MEAN.JS API - fix(debug): fixing gulp node debug task

### DIFF
--- a/server/gulpfile.js
+++ b/server/gulpfile.js
@@ -35,7 +35,7 @@ gulp.task('env:prod', function () {
 gulp.task('nodemon', function () {
   return plugins.nodemon({
     script: 'server.js',
-    nodeArgs: ['--debug'],
+    nodeArgs: ['--harmony'],
     ext: 'js,html',
     verbose: true,
     watch: _.union(defaultAssets.server.views, defaultAssets.server.allJS, defaultAssets.server.config)
@@ -43,9 +43,10 @@ gulp.task('nodemon', function () {
 });
 
 // Nodemon task without verbosity or debugging
-gulp.task('nodemon-nodebug', function () {
+gulp.task('nodemon-debug', function () {
   return plugins.nodemon({
     script: 'server.js',
+    nodeArgs: ['--harmony', '--debug', '--inspect'],
     ext: 'js,html',
     watch: _.union(defaultAssets.server.views, defaultAssets.server.allJS, defaultAssets.server.config)
   });
@@ -209,7 +210,7 @@ gulp.task('default', function (done) {
 
 // Run the project in debug mode
 gulp.task('debug', function (done) {
-  runSequence('env:dev', ['copyLocalEnvConfig', 'makeUploadsDir'], ['nodemon-nodebug', 'watch'], done);
+  runSequence('env:dev', ['copyLocalEnvConfig', 'makeUploadsDir'], ['nodemon-debug', 'watch'], done);
 });
 
 // Run the project in production mode

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "reinstall": "npm cache clean && npm run clean && npm install",
     "start": "gulp",
     "start:prod": "gulp prod",
-    "start:debug": "node-debug --web-host 0.0.0.0 server.js & gulp debug",
+    "start:debug": "gulp debug",
     "gulp": "gulp",
     "test": "gulp test",
     "test:server": "gulp test:server",


### PR DESCRIPTION
* fixing `npm start` to work with the --harmony flag
* fixing debug task to actually use --debug and --inspect in the new v8
