### PR TITLE
[v2] MEAN.JS API - fix(mongoose): fixing mongoose deprecation notice for promises

### DIFF
--- a/server/config/lib/mongoose.js
+++ b/server/config/lib/mongoose.js
@@ -46,10 +46,11 @@ module.exports.seed = function(dbConnection) {
 module.exports.connect = function() {
   return new Promise(function (resolve, reject) {
 
+    // Attach Node.js native Promises library implementation to Mongoose
+    mongoose.Promise = config.db.promise;
+
     mongoose.connect(config.db.uri, config.db.options)
       .then(function() {
-        // Attach Node.js native Promises library implementation to Mongoose
-        mongoose.Promise = config.db.promise;
 
         // Enabling mongoose debug mode if required
         mongoose.set('debug', config.db.debug);


### PR DESCRIPTION
If no promises library set correctly for the mongoose.Promise property then the following warning notice is omitted by mongoose: `DeprecationWarning: Mongoose: mpromise (mongoose's default promise library) is deprecated, plug in your own promise library instead: http://mongoosejs.com/docs/promises.html`