### PR TITLE
fix(mongoose): fixing mongoose deprecation notice for promises lib

### DIFF
--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -22,14 +22,14 @@ module.exports.loadModels = function (callback) {
 module.exports.connect = function (cb) {
   var _this = this;
 
+  mongoose.Promise = config.db.promise;
+
   var db = mongoose.connect(config.db.uri, config.db.options, function (err) {
     // Log Error
     if (err) {
       console.error(chalk.red('Could not connect to MongoDB!'));
       console.log(err);
     } else {
-
-      mongoose.Promise = config.db.promise;
 
       // Enabling mongoose debug mode if required
       mongoose.set('debug', config.db.debug);


### PR DESCRIPTION
If no promises library set correctly for the mongoose.Promise property then the following warning notice is omitted by mongoose:
`DeprecationWarning: Mongoose: mpromise (mongoose's default promise library) is deprecated, plug in your own promise library instead: http://mongoosejs.com/docs/promises.html`

