### PR TITLE
fix(core): Setting legacy watch option on nodemon for docker usage

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,6 +51,7 @@ gulp.task('nodemon', function () {
     script: 'server.js',
     nodeArgs: ['--debug'],
     ext: 'js,html',
+    legacyWatch: true, // This is required for nodemon to work in docker
     verbose: true,
     watch: _.union(defaultAssets.server.views, defaultAssets.server.allJS, defaultAssets.server.config)
   });
@@ -61,6 +62,7 @@ gulp.task('nodemon-nodebug', function () {
   return plugins.nodemon({
     script: 'server.js',
     ext: 'js,html',
+    legacyWatch: true, // This is required for nodemon to work in docker
     watch: _.union(defaultAssets.server.views, defaultAssets.server.allJS, defaultAssets.server.config)
   });
 });


### PR DESCRIPTION
This change is needed to get nodemon to work properly when run inside of a docker container. 

To replicated the issue run docker-compose up then make changes to files. You'll notice nodemon does not restart. 

This may be related to: #1110 #1621 #1625