### PR TITLE
Deprecating node-inspector infavor of native nodejs debug

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,7 @@ gulp.task('env:prod', function () {
 gulp.task('nodemon', function () {
   return plugins.nodemon({
     script: 'server.js',
-    nodeArgs: ['--debug'],
+    nodeArgs: ['--inspect'],
     ext: 'js,html',
     verbose: true,
     watch: _.union(defaultAssets.server.views, defaultAssets.server.allJS, defaultAssets.server.config)
@@ -433,14 +433,9 @@ gulp.task('test:coverage', function (done) {
   runSequence('env:test', ['copyLocalEnvConfig', 'makeUploadsDir', 'dropdb'], 'lint', 'mocha:coverage', 'karma:coverage', done);
 });
 
-// Run the project in development mode
+// Run the project in development mode with node debugger enabled
 gulp.task('default', function (done) {
   runSequence('env:dev', ['copyLocalEnvConfig', 'makeUploadsDir'], 'lint', ['nodemon', 'watch'], done);
-});
-
-// Run the project in debug mode
-gulp.task('debug', function (done) {
-  runSequence('env:dev', ['copyLocalEnvConfig', 'makeUploadsDir'], 'lint', ['nodemon-nodebug', 'watch'], done);
 });
 
 // Run the project in production mode

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/meanjs/mean.git"
   },
   "engines": {
-    "node": ">=4.6.0",
+    "node": ">=6.3.0",
     "npm": ">=3.10.8"
   },
   "scripts": {
@@ -112,7 +112,6 @@
     "karma-phantomjs-launcher": "~1.0.0",
     "lcov-result-merger": "~1.2.0",
     "mock-fs": "~3.11.0",
-    "node-inspector": "~0.12.8",
     "run-sequence": "~1.2.2",
     "semver": "~5.3.0",
     "should": "~11.1.0",


### PR DESCRIPTION
Deprecates the node-inspector package and relies on native Node.js support for the --debug option which is available since 6.3, and uses the --inspect flag which replaces --debug from v7 and on

Fixes issues reported in #1738 #1735 #1722 
