### PR TITLE
Removing unused mock-fs library which caused tests to fail

### DIFF
--- a/modules/core/tests/server/core.server.config.tests.js
+++ b/modules/core/tests/server/core.server.config.tests.js
@@ -9,7 +9,6 @@ var _ = require('lodash'),
   User = mongoose.model('User'),
   path = require('path'),
   fs = require('fs'),
-  mock = require('mock-fs'),
   request = require('supertest'),
   config = require(path.resolve('./config/config')),
   logger = require(path.resolve('./config/lib/logger')),
@@ -421,12 +420,10 @@ describe('Configuration Tests:', function () {
 
     beforeEach(function () {
       originalLogConfig = _.clone(config.log, true);
-      mock();
     });
 
     afterEach(function () {
       config.log = originalLogConfig;
-      mock.restore();
     });
 
     it('should retrieve the log format from the logger configuration', function () {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "karma-ng-html2js-preprocessor": "~1.0.0",
     "karma-phantomjs-launcher": "~1.0.0",
     "lcov-result-merger": "~1.2.0",
-    "mock-fs": "~3.12.0",
     "run-sequence": "~1.2.2",
     "semver": "~5.3.0",
     "should": "~11.1.0",


### PR DESCRIPTION
mock-fs will override node's core fs calls which mess up the tests.