### PR TITLE
fix(dependencies): upgrading nodemailer

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mongoose": "~4.9.3",
     "morgan": "~1.8.1",
     "multer": "~1.3.0",
-    "nodemailer": "~2.6.4",
+    "nodemailer": "~4.0.0",
     "owasp-password-strength-test": "~1.3.0",
     "passport": "~0.3.2",
     "passport-facebook": "~2.1.1",


### PR DESCRIPTION
Looking at the new docs for NodeMailer it seems we can upgrade safely as the same simple SMTP transport creation remains compatible.