### PR TITLE
build(gems): we shouldnt need any gem file installations anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ addons:
     - gcc-4.8
     - clang
 before_install:
-  - gem update --system
-  - gem install sass --version "=3.3.7"
   - npm i nsp -g
   - npm i snyk -g
   - export DISPLAY=:99.0


### PR DESCRIPTION
Ever since we moved out to node-sass we shouldn't really have any dependencies on ruby gemfiles