### PR TITLE
fix(build): E2E coverage broken on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - npm install protractor
   - 'export DISPLAY=:99.0'
   - 'sh -e /etc/init.d/xvfb start'
-  - 'node_modules/protractor/bin/webdriver-manager update --standalone --firefox'
+  - 'node_modules/protractor/bin/webdriver-manager update --standalone'
   - 'node_modules/protractor/bin/webdriver-manager start 2>&1 &'
   - sleep 3
 #before_script:

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "gulp-mocha": "~3.0.1",
     "gulp-ng-annotate": "~2.0.0",
     "gulp-nodemon": "~2.2.1",
-    "gulp-protractor": "^3.0.0",
+    "gulp-protractor": "^4.0.0",
     "gulp-refresh": "~1.1.0",
     "gulp-rename": "~1.2.2",
     "gulp-rev": "^7.1.2",

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -7,7 +7,12 @@ var config = {
 
 if (process.env.TRAVIS) {
   config.capabilities = {
-    browserName: 'firefox'
+    // Without this setting, Travis CI would default
+    // to using Chrome anyway.
+    // NOTE: Firefox is currently not working with
+    // the Travis CI builds. For more info see:
+    // https://github.com/meanjs/mean/pull/1805
+    browserName: 'chrome'
   };
 }
 


### PR DESCRIPTION
Fixes an issue with the Travis CI builds failing at the E2E tests due to
an apparent issue with the Mozilla Gecko web-driver used with Selenium.

1) Upgrades `gulp-protractor` to ensure Protractor v5> is used.
2) Removes `--firefox` option from the Travis CI Selenium
`webdriver-manager update` step.
3) Changes Protractor config to use Chrome instead of Firefox.

**NOTE:** This PR was originally created on a debugging branch to determine the issues with the E2E tests running on Travis CI builds. The below conversation will reflect the process of numerous experimental commits to track down the source of the issues. After a conclusion was made, the commits in this branch were squashed, and the commit details were changed here.
