### PR TITLE
fix(build): ESLint error in Express config

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -142,7 +142,7 @@ module.exports.initModulesConfiguration = function (app, db) {
 module.exports.initHelmetHeaders = function (app) {
   // six months expiration period specified in seconds
   var SIX_MONTHS = 15778476;
-  
+
   app.use(helmet.frameguard());
   app.use(helmet.xssFilter());
   app.use(helmet.noSniff());


### PR DESCRIPTION
Fixes a trailing space eslint error in the Express config.
