### PR TITLE
fix(mongodb): update ssl connection settings

### DIFF
--- a/config/env/production.js
+++ b/config/env/production.js
@@ -18,19 +18,19 @@ module.exports = {
       user: '',
       pass: ''
       /**
-        * Uncomment to enable ssl certificate based authentication to mongodb
-        * servers. Adjust the settings below for your specific certificate
-        * setup.
-        * for connect to a replicaset, rename server:{...} to replset:{...}
-      server: {
-        ssl: true,
-        sslValidate: false,
-        checkServerIdentity: false,
-        sslCA: fs.readFileSync('./config/sslcerts/ssl-ca.pem'),
-        sslCert: fs.readFileSync('./config/sslcerts/ssl-cert.pem'),
-        sslKey: fs.readFileSync('./config/sslcerts/ssl-key.pem'),
-        sslPass: '1234'
-      }
+      * Uncomment to enable ssl certificate based authentication to mongodb
+      * servers. Adjust the settings below for your specific certificate
+      * setup.
+      * for connect to a replicaset, rename server:{...} to replset:{...}
+
+      ssl: true,
+      sslValidate: false,
+      checkServerIdentity: false,
+      sslCA: fs.readFileSync('./config/sslcerts/ssl-ca.pem'),
+      sslCert: fs.readFileSync('./config/sslcerts/ssl-cert.pem'),
+      sslKey: fs.readFileSync('./config/sslcerts/ssl-key.pem'),
+      sslPass: '1234'
+
       */
     },
     // Enable mongoose debug mode


### PR DESCRIPTION
Updating SSL connection settings to be in-par with new versions of Mongoose.
Related issue: https://github.com/meanjs/mean/commit/c0f6cb3e4d1a2cf5d1540643f3ce79934f5d957b#commitcomment-22974350