### PR TITLE
lock node/npm versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "url": "https://github.com/meanjs/mean.git"
   },
   "engines": {
-    "node": ">=6.10.0",
-    "npm": ">=3.10.8"
+    "node": "6.9.1",
+    "npm": "3.10.8"
   },
   "scripts": {
     "update": "npm update && npm prune && npm run bower",


### PR DESCRIPTION
lock node/npm versions else it would try to use npm5 if available which has some known issues and not stable yet.

I'm using node 6.9.1 as an example but may be we can lock it for other node version.
