### PR TITLE
feat(Travis): Don't allow Node.js 8 testing fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ node_js:
   - '8'
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: '8'
+#  allow_failures:
+#    - node_js: '8'
 os:
   - linux
   - centos


### PR DESCRIPTION
I felt like leaving these just uncommented so it helps in future when people want to add new versions here.

I can also remove them completely (or remove only `allow_failures`) if you think it's better.