### PR TITLE
feat(config): Mongoose 4.11 upgrade

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -5,10 +5,7 @@ var defaultEnvConfig = require('./default');
 module.exports = {
   db: {
     uri: process.env.MONGOHQ_URL || process.env.MONGODB_URI || 'mongodb://' + (process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost') + '/mean-dev',
-    options: {
-      user: '',
-      pass: ''
-    },
+    options: {},
     // Enable mongoose debug mode
     debug: process.env.MONGODB_DEBUG || false
   },

--- a/config/env/local.example.js
+++ b/config/env/local.example.js
@@ -20,10 +20,7 @@
 module.exports = {
   db: {
     uri: 'mongodb://localhost/local-dev',
-    options: {
-      user: '',
-      pass: ''
-    }
+    options: {}
   },
   sessionSecret: process.env.SESSION_SECRET || 'youshouldchangethistosomethingsecret',
   facebook: {

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -15,8 +15,6 @@ module.exports = {
   db: {
     uri: process.env.MONGOHQ_URL || process.env.MONGODB_URI || 'mongodb://' + (process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost') + '/mean',
     options: {
-      user: '',
-      pass: ''
       /**
         * Uncomment to enable ssl certificate based authentication to mongodb
         * servers. Adjust the settings below for your specific certificate

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -5,10 +5,7 @@ var defaultEnvConfig = require('./default');
 module.exports = {
   db: {
     uri: process.env.MONGOHQ_URL || process.env.MONGODB_URI || 'mongodb://' + (process.env.DB_1_PORT_27017_TCP_ADDR || 'localhost') + '/mean-test',
-    options: {
-      user: '',
-      pass: ''
-    },
+    options: {},
     // Enable mongoose debug mode
     debug: process.env.MONGODB_DEBUG || false
   },

--- a/config/lib/app.js
+++ b/config/lib/app.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 var config = require('../config'),
-  mongoose = require('./mongoose'),
+  mongooseService = require('./mongoose'),
   express = require('./express'),
   chalk = require('chalk'),
   seed = require('./seed');
@@ -16,11 +16,11 @@ function seedDB() {
   }
 }
 
-// Initialize Models
-mongoose.loadModels(seedDB);
-
 module.exports.init = function init(callback) {
-  mongoose.connect(function (db) {
+  mongooseService.connect(function (db) {
+    // Initialize Models
+    mongooseService.loadModels(seedDB);
+
     // Initialize express
     var app = express.init(db);
     if (callback) callback(app, db, config);

--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -118,7 +118,7 @@ module.exports.initSession = function (app, db) {
     },
     name: config.sessionKey,
     store: new MongoStore({
-      mongooseConnection: db.connection,
+      db: db,
       collection: config.sessionCollection
     })
   }));
@@ -130,9 +130,9 @@ module.exports.initSession = function (app, db) {
 /**
  * Invoke modules server configuration
  */
-module.exports.initModulesConfiguration = function (app, db) {
+module.exports.initModulesConfiguration = function (app) {
   config.files.server.configs.forEach(function (configPath) {
-    require(path.resolve(configPath))(app, db);
+    require(path.resolve(configPath))(app);
   });
 };
 

--- a/config/lib/mongoose.js
+++ b/config/lib/mongoose.js
@@ -3,7 +3,8 @@
 /**
  * Module dependencies.
  */
-var config = require('../config'),
+var _ = require('lodash'),
+  config = require('../config'),
   chalk = require('chalk'),
   path = require('path'),
   mongoose = require('mongoose');
@@ -19,30 +20,31 @@ module.exports.loadModels = function (callback) {
 };
 
 // Initialize Mongoose
-module.exports.connect = function (cb) {
-  var _this = this;
-
+module.exports.connect = function (callback) {
   mongoose.Promise = config.db.promise;
 
-  var db = mongoose.connect(config.db.uri, config.db.options, function (err) {
-    // Log Error
-    if (err) {
-      console.error(chalk.red('Could not connect to MongoDB!'));
-      console.log(err);
-    } else {
+  var options = _.merge(config.db.options || {}, { useMongoClient: true });
 
+  mongoose
+    .connect(config.db.uri, options)
+    .then(function (connection) {
       // Enabling mongoose debug mode if required
       mongoose.set('debug', config.db.debug);
 
       // Call callback FN
-      if (cb) cb(db);
-    }
-  });
+      if (callback) callback(connection.db);
+    })
+    .catch(function (err) {
+      console.error(chalk.red('Could not connect to MongoDB!'));
+      console.log(err);
+    });
+
 };
 
 module.exports.disconnect = function (cb) {
-  mongoose.disconnect(function (err) {
-    console.info(chalk.yellow('Disconnected from MongoDB.'));
-    cb(err);
-  });
+  mongoose.connection.db
+    .close(function (err) {
+      console.info(chalk.yellow('Disconnected from MongoDB.'));
+      return cb(err);
+    });
 };

--- a/config/lib/socket.io.js
+++ b/config/lib/socket.io.js
@@ -71,7 +71,7 @@ module.exports = function (app, db) {
 
   // Create a MongoDB storage object
   var mongoStore = new MongoStore({
-    mongooseConnection: db.connection,
+    db: db,
     collection: config.sessionCollection
   });
 

--- a/modules/articles/server/config/articles.server.config.js
+++ b/modules/articles/server/config/articles.server.config.js
@@ -9,6 +9,6 @@ var path = require('path'),
 /**
  * Module init function.
  */
-module.exports = function (app, db) {
+module.exports = function (app) {
 
 };

--- a/modules/articles/tests/server/admin.article.server.routes.tests.js
+++ b/modules/articles/tests/server/admin.article.server.routes.tests.js
@@ -23,7 +23,7 @@ var app,
 describe('Article Admin CRUD tests', function () {
   before(function (done) {
     // Get application
-    app = express.init(mongoose);
+    app = express.init(mongoose.connection.db);
     agent = request.agent(app);
 
     done();

--- a/modules/articles/tests/server/article.server.routes.tests.js
+++ b/modules/articles/tests/server/article.server.routes.tests.js
@@ -24,7 +24,7 @@ describe('Article CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose);
+    app = express.init(mongoose.connection.db);
     agent = request.agent(app);
 
     done();
@@ -119,7 +119,7 @@ describe('Article CRUD tests', function () {
     // Save the article
     articleObj.save(function () {
       // Request articles
-      request(app).get('/api/articles')
+      agent.get('/api/articles')
         .end(function (req, res) {
           // Set assertion
           res.body.should.be.instanceof(Array).and.have.lengthOf(1);
@@ -137,7 +137,7 @@ describe('Article CRUD tests', function () {
 
     // Save the article
     articleObj.save(function () {
-      request(app).get('/api/articles/' + articleObj._id)
+      agent.get('/api/articles/' + articleObj._id)
         .end(function (req, res) {
           // Set assertion
           res.body.should.be.instanceof(Object).and.have.property('title', article.title);
@@ -150,7 +150,7 @@ describe('Article CRUD tests', function () {
 
   it('should return proper error for single article with an invalid Id, if not signed in', function (done) {
     // test is not a valid mongoose Id
-    request(app).get('/api/articles/test')
+    agent.get('/api/articles/test')
       .end(function (req, res) {
         // Set assertion
         res.body.should.be.instanceof(Object).and.have.property('message', 'Article is invalid');
@@ -162,7 +162,7 @@ describe('Article CRUD tests', function () {
 
   it('should return proper error for single article which doesnt exist, if not signed in', function (done) {
     // This is a valid mongoose Id but a non-existent article
-    request(app).get('/api/articles/559e9cd815f80b4c256a8f41')
+    agent.get('/api/articles/559e9cd815f80b4c256a8f41')
       .end(function (req, res) {
         // Set assertion
         res.body.should.be.instanceof(Object).and.have.property('message', 'No article with that identifier has been found');
@@ -202,7 +202,7 @@ describe('Article CRUD tests', function () {
     // Save the article
     articleObj.save(function () {
       // Try deleting article
-      request(app).delete('/api/articles/' + articleObj._id)
+      agent.delete('/api/articles/' + articleObj._id)
         .expect(403)
         .end(function (articleDeleteErr, articleDeleteRes) {
           // Set message assertion
@@ -312,7 +312,7 @@ describe('Article CRUD tests', function () {
       if (err) {
         return done(err);
       }
-      request(app).get('/api/articles/' + articleObj._id)
+      agent.get('/api/articles/' + articleObj._id)
         .end(function (req, res) {
           // Set assertion
           res.body.should.be.instanceof(Object).and.have.property('title', article.title);

--- a/modules/core/tests/server/core.server.config.tests.js
+++ b/modules/core/tests/server/core.server.config.tests.js
@@ -517,7 +517,7 @@ describe('Configuration Tests:', function () {
         process.env.NODE_ENV = env;
 
         // Gget application
-        app = express.init(mongoose);
+        app = express.init(mongoose.connection.db);
         agent = request.agent(app);
 
         // Get rendered layout

--- a/modules/users/server/config/users.server.config.js
+++ b/modules/users/server/config/users.server.config.js
@@ -11,7 +11,7 @@ var passport = require('passport'),
 /**
  * Module init function
  */
-module.exports = function (app, db) {
+module.exports = function (app) {
   // Serialize sessions
   passport.serializeUser(function (user, done) {
     done(null, user.id);

--- a/modules/users/tests/server/user.server.routes.tests.js
+++ b/modules/users/tests/server/user.server.routes.tests.js
@@ -26,7 +26,7 @@ describe('User CRUD tests', function () {
 
   before(function (done) {
     // Get application
-    app = express.init(mongoose);
+    app = express.init(mongoose.connection.db);
     agent = request.agent(app);
 
     done();

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lusca": "~1.4.1",
     "method-override": "~2.3.8",
     "mocha": "~3.4.2",
-    "mongoose": "~4.10.2",
+    "mongoose": "~4.11.3",
     "morgan": "~1.8.1",
     "multer": "~1.3.0",
     "nodemailer": "~4.0.1",


### PR DESCRIPTION
Upgrades Mongoose to ~~4.11.1~~ 4.11.3

Updates Mongoose connection implementation to accommodate deprecated
features & connection options.

Also, updates the Gulp Mocha tasks to reflect changes to the Mongoose
implementation.

Fixes tests to get the database from the existing Mongoose singleton.

Derives from changes in https://github.com/meanjs/mean/pull/1816

Closes https://github.com/meanjs/mean/issues/1814
