### PR TITLE
fix(gulpfile): Update templateCache root path

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -266,7 +266,7 @@ gulp.task('makeUploadsDir', function () {
 gulp.task('templatecache', function () {
   return gulp.src(defaultAssets.client.views)
     .pipe(plugins.templateCache('templates.js', {
-      root: 'modules/',
+      root: '/modules/',
       module: 'core',
       templateHeader: '(function () {' + endOfLine + '	\'use strict\';' + endOfLine + endOfLine + '	angular' + endOfLine + '		.module(\'<%= module %>\'<%= standalone %>)' + endOfLine + '		.run(templates);' + endOfLine + endOfLine + '	templates.$inject = [\'$templateCache\'];' + endOfLine + endOfLine + '	function templates($templateCache) {' + endOfLine,
       templateBody: '		$templateCache.put(\'<%= url %>\', \'<%= contents %>\');',


### PR DESCRIPTION
fix(gulpfile): Update templateCache root path

In the production build `application-xxx.min.js`, the url of the mark up being put into `$templateCache` is incorrect, the `/` is missing.

Although the mark-ups are already put into `$templateCache`, the browser will still fetch the templates files when they are needed.

Fixes #1820 