### PR TITLE
feat(user): Add email support to forgot password

### DIFF
--- a/modules/users/client/views/password/forgot-password.client.view.html
+++ b/modules/users/client/views/password/forgot-password.client.view.html
@@ -1,17 +1,17 @@
 <section class="row">
   <h3 class="col-md-12 text-center">Restore your password</h3>
-  <p class="small text-center">Enter your account username.</p>
   <div class="col-xs-offset-2 col-xs-8 col-md-offset-5 col-md-2">
     <form name="vm.forgotPasswordForm" ng-submit="vm.askForPasswordReset(vm.forgotPasswordForm.$valid)" class="form-horizontal" novalidate autocomplete="off">
       <fieldset>
         <div class="form-group" show-errors>
-          <input type="text" id="username" name="username" class="form-control" ng-model="vm.credentials.username" placeholder="Username" lowercase required autofocus>
-          <div ng-messages="vm.forgotPasswordForm.username.$error" role="alert">
-            <p class="help-block error-text" ng-message="required">Enter a username.</p>
+          <label for="userhandle" class="text-center">Enter your account username or email.</label>
+          <input type="text" id="userhandle" name="userhandle" class="form-control" ng-model="vm.credentials.userhandle" lowercase required autofocus>
+          <div ng-messages="vm.forgotPasswordForm.userhandle.$error" role="alert">
+            <p class="help-block error-text" ng-message="required">Enter a username or email.</p>
           </div>
         </div>
         <div class="text-center form-group">
-          <button type="submit" class="btn btn-primary">Submit</button>
+          <button type="submit" class="btn btn-primary">Restore</button>
         </div>
       </fieldset>
     </form>

--- a/modules/users/client/views/password/forgot-password.client.view.html
+++ b/modules/users/client/views/password/forgot-password.client.view.html
@@ -4,9 +4,9 @@
     <form name="vm.forgotPasswordForm" ng-submit="vm.askForPasswordReset(vm.forgotPasswordForm.$valid)" class="form-horizontal" novalidate autocomplete="off">
       <fieldset>
         <div class="form-group" show-errors>
-          <label for="userhandle" class="text-center">Enter your account username or email.</label>
-          <input type="text" id="userhandle" name="userhandle" class="form-control" ng-model="vm.credentials.userhandle" lowercase required autofocus>
-          <div ng-messages="vm.forgotPasswordForm.userhandle.$error" role="alert">
+          <label for="usernameOrEmail" class="text-center">Enter your account username or email.</label>
+          <input type="text" id="usernameOrEmail" name="usernameOrEmail" class="form-control" ng-model="vm.credentials.usernameOrEmail" lowercase required autofocus>
+          <div ng-messages="vm.forgotPasswordForm.usernameOrEmail.$error" role="alert">
             <p class="help-block error-text" ng-message="required">Enter a username or email.</p>
           </div>
         </div>

--- a/modules/users/server/controllers/users/users.password.server.controller.js
+++ b/modules/users/server/controllers/users/users.password.server.controller.js
@@ -28,14 +28,14 @@ exports.forgot = function (req, res, next) {
     },
     // Lookup user by username
     function (token, done) {
-      if (req.body.userhandle) {
+      if (req.body.usernameOrEmail) {
 
-        var userhandle = req.body.userhandle.toLowerCase();
+        var usernameOrEmail = String(req.body.usernameOrEmail).toLowerCase();
 
         User.findOne({
           $or: [
-            { username: userhandle },
-            { email: userhandle }
+            { username: usernameOrEmail },
+            { email: usernameOrEmail }
           ]
         }, '-salt -password', function (err, user) {
           if (err || !user) {

--- a/modules/users/server/controllers/users/users.password.server.controller.js
+++ b/modules/users/server/controllers/users/users.password.server.controller.js
@@ -28,17 +28,23 @@ exports.forgot = function (req, res, next) {
     },
     // Lookup user by username
     function (token, done) {
-      if (req.body.username) {
+      if (req.body.userhandle) {
+
+        var userhandle = req.body.userhandle.toLowerCase();
+
         User.findOne({
-          username: req.body.username.toLowerCase()
+          $or: [
+            { username: userhandle },
+            { email: userhandle }
+          ]
         }, '-salt -password', function (err, user) {
           if (err || !user) {
             return res.status(400).send({
-              message: 'No account with that username has been found'
+              message: 'No account with that username or email has been found'
             });
           } else if (user.provider !== 'local') {
             return res.status(400).send({
-              message: 'It seems like you signed up using your ' + user.provider + ' account'
+              message: 'It seems like you signed up using your ' + user.provider + ' account, please sign in using that provider.'
             });
           } else {
             user.resetPasswordToken = token;
@@ -51,7 +57,7 @@ exports.forgot = function (req, res, next) {
         });
       } else {
         return res.status(422).send({
-          message: 'Username field must not be blank'
+          message: 'Username/email field must not be blank'
         });
       }
     },

--- a/modules/users/tests/server/user.server.routes.tests.js
+++ b/modules/users/tests/server/user.server.routes.tests.js
@@ -325,7 +325,7 @@ describe('User CRUD tests', function () {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          userhandle: 'some_username_that_doesnt_exist'
+          usernameOrEmail: 'some_username_that_doesnt_exist'
         })
         .expect(400)
         .end(function (err, res) {
@@ -349,7 +349,7 @@ describe('User CRUD tests', function () {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          userhandle: ''
+          usernameOrEmail: ''
         })
         .expect(422)
         .end(function (err, res) {
@@ -395,7 +395,7 @@ describe('User CRUD tests', function () {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          userhandle: user.username
+          usernameOrEmail: user.username
         })
         .expect(400)
         .end(function (err, res) {
@@ -417,7 +417,7 @@ describe('User CRUD tests', function () {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          userhandle: user.username
+          usernameOrEmail: user.username
         })
         .expect(400)
         .end(function (err, res) {
@@ -443,7 +443,7 @@ describe('User CRUD tests', function () {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          userhandle: user.email
+          usernameOrEmail: user.email
         })
         .expect(400)
         .end(function (err, res) {
@@ -469,7 +469,7 @@ describe('User CRUD tests', function () {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          userhandle: user.username
+          usernameOrEmail: user.username
         })
         .expect(400)
         .end(function (err, res) {
@@ -506,7 +506,7 @@ describe('User CRUD tests', function () {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          userhandle: user.username
+          usernameOrEmail: user.username
         })
         .expect(400)
         .end(function (err, res) {

--- a/modules/users/tests/server/user.server.routes.tests.js
+++ b/modules/users/tests/server/user.server.routes.tests.js
@@ -325,7 +325,7 @@ describe('User CRUD tests', function () {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          username: 'some_username_that_doesnt_exist'
+          userhandle: 'some_username_that_doesnt_exist'
         })
         .expect(400)
         .end(function (err, res) {
@@ -334,13 +334,13 @@ describe('User CRUD tests', function () {
             return done(err);
           }
 
-          res.body.message.should.equal('No account with that username has been found');
+          res.body.message.should.equal('No account with that username or email has been found');
           return done();
         });
     });
   });
 
-  it('forgot password should return 400 for no username provided', function (done) {
+  it('forgot password should return 400 for empty username/email', function (done) {
     var provider = 'facebook';
     user.provider = provider;
     user.roles = ['user'];
@@ -349,7 +349,7 @@ describe('User CRUD tests', function () {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          username: ''
+          userhandle: ''
         })
         .expect(422)
         .end(function (err, res) {
@@ -358,7 +358,29 @@ describe('User CRUD tests', function () {
             return done(err);
           }
 
-          res.body.message.should.equal('Username field must not be blank');
+          res.body.message.should.equal('Username/email field must not be blank');
+          return done();
+        });
+    });
+  });
+
+  it('forgot password should return 400 for no username or email provided', function (done) {
+    var provider = 'facebook';
+    user.provider = provider;
+    user.roles = ['user'];
+
+    user.save(function (err) {
+      should.not.exist(err);
+      agent.post('/api/auth/forgot')
+        .send({})
+        .expect(422)
+        .end(function (err, res) {
+          // Handle error
+          if (err) {
+            return done(err);
+          }
+
+          res.body.message.should.equal('Username/email field must not be blank');
           return done();
         });
     });
@@ -373,7 +395,7 @@ describe('User CRUD tests', function () {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          username: user.username
+          userhandle: user.username
         })
         .expect(400)
         .end(function (err, res) {
@@ -382,20 +404,46 @@ describe('User CRUD tests', function () {
             return done(err);
           }
 
-          res.body.message.should.equal('It seems like you signed up using your ' + user.provider + ' account');
+          res.body.message.should.equal('It seems like you signed up using your ' + user.provider + ' account, please sign in using that provider.');
           return done();
         });
     });
   });
 
-  it('forgot password should be able to reset password for user password reset request', function (done) {
+  it('forgot password should be able to reset password for user password reset request using username', function (done) {
     user.roles = ['user'];
 
     user.save(function (err) {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          username: user.username
+          userhandle: user.username
+        })
+        .expect(400)
+        .end(function (err, res) {
+          // Handle error
+          if (err) {
+            return done(err);
+          }
+
+          User.findOne({ username: user.username.toLowerCase() }, function(err, userRes) {
+            userRes.resetPasswordToken.should.not.be.empty();
+            should.exist(userRes.resetPasswordExpires);
+            res.body.message.should.be.equal('Failure sending email');
+            return done();
+          });
+        });
+    });
+  });
+
+  it('forgot password should be able to reset password for user password reset request using email', function (done) {
+    user.roles = ['user'];
+
+    user.save(function (err) {
+      should.not.exist(err);
+      agent.post('/api/auth/forgot')
+        .send({
+          userhandle: user.email
         })
         .expect(400)
         .end(function (err, res) {
@@ -421,7 +469,7 @@ describe('User CRUD tests', function () {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          username: user.username
+          userhandle: user.username
         })
         .expect(400)
         .end(function (err, res) {
@@ -458,7 +506,7 @@ describe('User CRUD tests', function () {
       should.not.exist(err);
       agent.post('/api/auth/forgot')
         .send({
-          username: user.username
+          userhandle: user.username
         })
         .expect(400)
         .end(function (err, res) {


### PR DESCRIPTION
Adds support for recovering your account using email. Previously this would work only with username. Now both are supported.

Breaking change to API (`username` field changed to `userhandle`), but it's really simple to fix if anyone out there is relying on that e.g. with their mobile apps.

Resolves #1833