### PR TITLE
fix(users): don't fail on missing old image on image upload

### DIFF
--- a/modules/users/server/controllers/users/users.profile.server.controller.js
+++ b/modules/users/server/controllers/users/users.profile.server.controller.js
@@ -111,7 +111,15 @@ exports.changeProfilePicture = function (req, res) {
       if (existingImageUrl !== User.schema.path('profileImageURL').defaultValue) {
         fs.unlink(existingImageUrl, function (unlinkError) {
           if (unlinkError) {
-            console.log(unlinkError);
+
+            // If file didn't exist, no need to reject promise
+            if (unlinkError.code === 'ENOENT') {
+              console.log('Removing profile image failed because file did not exist.');
+              return resolve();
+            }
+
+            console.error(unlinkError);
+
             reject({
               message: 'Error occurred while deleting old profile picture'
             });

--- a/modules/users/tests/server/user.server.routes.tests.js
+++ b/modules/users/tests/server/user.server.routes.tests.js
@@ -1059,6 +1059,26 @@ describe('User CRUD tests', function () {
       });
   });
 
+  it('should not be able to change profile picture to too big of a file', function (done) {
+    agent.post('/api/auth/signin')
+      .send(credentials)
+      .expect(200)
+      .end(function (signinErr) {
+        // Handle signin error
+        if (signinErr) {
+          return done(signinErr);
+        }
+
+        agent.post('/api/users/picture')
+          .attach('newProfilePicture', './modules/users/tests/server/img/too-big-file.png')
+          .send(credentials)
+          .expect(422)
+          .end(function (userInfoErr, userInfoRes) {
+            done(userInfoErr);
+          });
+      });
+  });
+
   it('should be able to change profile picture and not fail if existing picture file does not exist', function (done) {
 
     user.profileImageURL = config.uploads.profile.image.dest + 'non-existing.png';


### PR DESCRIPTION
Silently fails when existing file didn't exist when unlinking it.

Fixes #1778