### PR TITLE
feat(build): Turn on mangling for uglify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -153,7 +153,7 @@ gulp.task('uglify', function () {
   return gulp.src(assets)
     .pipe(plugins.ngAnnotate())
     .pipe(plugins.uglify({
-      mangle: false
+      mangle: true
     }))
     .pipe(plugins.concat('application.min.js'))
     .pipe(plugins.rev())


### PR DESCRIPTION
Previously this might've caused issues with AngularJS, but since we are now using ngAnnotate, those issues are gone.

Minified files will be quite a lot smaller with this option.

I did some manual clicking around and seemed working fine.

https://github.com/mishoo/UglifyJS2#minify-options

Closes #1599 