### PR TITLE
fix(gulp): test:server:watch broken task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,11 +109,10 @@ gulp.task('watch:server:run-tests', function () {
 
         if (filePath === path.resolve(file.path)) {
           changedTestFiles.push(f);
+          plugins.refresh.changed(f);
         }
       });
     });
-
-    plugins.refresh.changed();
   });
 });
 


### PR DESCRIPTION
Pass the path string of the changed file to gulp-refresh plugin,
so that an exception won't be thrown when test files are reloaded

Fixes #1840