### PR TITLE
Remove deprecated crypto package

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "connect-flash": "~0.1.1",
     "connect-mongo": "~1.3.2",
     "cookie-parser": "~1.4.1",
-    "crypto": "0.0.3",
     "express": "~4.15.2",
     "express-hbs": "^1.0.4",
     "express-session": "~1.15.2",


### PR DESCRIPTION
`crypto` is now part of NodeJS core: https://www.npmjs.com/package/crypto
