### PR TITLE
fix(travis): Fix Travis failing on webdriver issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ addons:
     - clang
     - google-chrome-stable
 before_install:
+  - npm install webdriver-manager -g && webdriver-manager update
   - npm install nsp -g
 #  - npm install snyk -g
   - 'export PATH=$PATH:/usr/lib/chromium-browser/'


### PR DESCRIPTION
Travis is randomly failing at:
```
[08:34:29] I/launcher - Running 1 instances of WebDriver
[08:34:29] E/local - Error code: 135
[08:34:29] E/local - Error message: No update-config.json found. Run 'webdriver-manager update' to download binaries.
[08:34:29] E/local - Error: No update-config.json found. Run 'webdriver-manager update' to download binaries.
```

So let's see if this helps.