### PR TITLE
fix(eslint): Make `space-before-function-paren` rule consistent with other rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,7 @@ module.exports = {
     'one-var': [0, 'never'],
     'one-var-declaration-per-line': [2, 'always'],
     'padded-blocks': 0,
-    'space-before-function-paren': ['error', {
+    'space-before-function-paren': [2, {
       'anonymous': 'always',
       'named': 'never',
       'asyncArrow': 'always'


### PR DESCRIPTION
Fixes eslint errors in eslint 4.x:
```
Linter] Error running ESLint Error: /mean/.eslintrc.js:
	Configuration for rule "space-before-function-paren" is invalid:
	Severity should be one of the following: 0 = off, 1 = warning, 2 = error (you passed "error").
```

We're still in eslint 2.x. so apparently no problems as of yet, but will have to be fixed before updating eslint (#1846).

Related to previous PR #1844 and already closed issue #1605