### PR TITLE
Manage articles - no articles alert missing.

### DIFF
--- a/modules/articles/client/views/admin/list-articles.client.view.html
+++ b/modules/articles/client/views/admin/list-articles.client.view.html
@@ -20,7 +20,7 @@
       <p class="list-group-item-text" data-ng-bind="article.content"></p>
     </a>
   </div>
-  <div class="alert alert-warning text-center" data-ng-if="articles.$resolved && !articles.length">
+  <div class="alert alert-warning text-center" data-ng-if="vm.articles.$resolved && !articles.length">
     No articles yet, why don't you <a data-ui-sref="admin.articles.create">create one</a>?
   </div>
 </section>


### PR DESCRIPTION
fix(articles) Alert missing.

In the Admin - 'manage articles' view, if there are no articles yet there's supposed to be an alert.
However, it doesn't show up.

Fixes #1930
