### PR TITLE
Manage Article - Updating the warning message condition

### DIFF
--- a/modules/articles/client/views/admin/list-articles.client.view.html
+++ b/modules/articles/client/views/admin/list-articles.client.view.html
@@ -20,7 +20,7 @@
       <p class="list-group-item-text" data-ng-bind="article.content"></p>
     </a>
   </div>
-  <div class="alert alert-warning text-center" data-ng-if="vm.articles.$resolved && !articles.length">
+  <div class="alert alert-warning text-center" data-ng-if="vm.articles.$resolved && !vm.articles.length">
     No articles yet, why don't you <a data-ui-sref="admin.articles.create">create one</a>?
   </div>
 </section>


### PR DESCRIPTION
fix(articles): Updated warning message condition

In the Admin - 'manage articles' view, the warning message will be displayed only when there is no article present.

Fixes #1930 ,Fixes #1933 