### PR TITLE
feat(core): Improve links in home view

### DIFF
--- a/modules/core/client/views/home.client.view.html
+++ b/modules/core/client/views/home.client.view.html
@@ -13,7 +13,7 @@
     </div>
     <div class="row">
       <p>
-        <a class="btn btn-primary btn-lg" href="http://meanjs.org" target="_blank">Learn more</a>
+        <a class="btn btn-primary btn-lg" href="https://meanjs.org" target="_blank" rel="noopener">Learn more</a>
       </p>
     </div>
   </div>
@@ -44,19 +44,19 @@
   <div class="row">
     <div class="col-md-3">
       <h2><strong>M</strong>ongoDB</h2>
-      <p><a target="_blank" href="http://mongodb.org/">MongoDB</a> is a NoSQL database. MongoDB's <a target="_blank" href="http://docs.mongodb.org/manual/">great manual</a> is the place to get started with NoSQL and MongoDB.</p>
+      <p><a target="_blank" href="https://www.mongodb.com/" rel="noopener">MongoDB</a> is a NoSQL database. MongoDB's <a target="_blank" href="https://docs.mongodb.com/manual/" rel="noopener">great manual</a> is the place to get started with NoSQL and MongoDB.</p>
     </div>
     <div class="col-md-3">
       <h2><strong>E</strong>xpress</h2>
-      <p><a target="_blank" href="http://expressjs.com/"> Express</a> is a NodeJS server-side application web framework. Check out <a target="_blank" href="http://expressjs.com/4x/api.html">The ExpressJS API reference for more information</a> or <a target="_blank" href="http://stackoverflow.com/questions/8144214/learning-express-for-node-js">StackOverflow</a> for more info.</p>
+      <p><a target="_blank" href="https://expressjs.com/" rel="noopener"> Express</a> is a NodeJS server-side application web framework. Check out <a target="_blank" href="https://expressjs.com/en/4x/api.html" rel="noopener">The ExpressJS API reference for more information</a>.</p>
     </div>
     <div class="col-md-3">
       <h2><strong>A</strong>ngularJS</h2>
-      <p><a target="_blank" href="http://angularjs.org/">AngularJS</a> is client-side web application framework. The <a target="_blank" href="http://www.thinkster.io/">Thinkster Popular Guide</a> and <a target="_blank" href="https://egghead.io/">Egghead Videos</a> are great resources.</p>
+      <p><a target="_blank" href="https://angularjs.org/" rel="noopener">AngularJS</a> is client-side web application framework. The <a target="_blank" href="https://thinkster.io/" rel="noopener">Thinkster Popular Guide</a> and <a target="_blank" href="https://egghead.io/" rel="noopener">Egghead Videos</a> are great resources.</p>
     </div>
     <div class="col-md-3">
       <h2><strong>N</strong>ode.js</h2>
-      <p><a target="_blank" href="http://nodejs.org/">Node.js</a> is a JavaScript run-time, popular for being a web server platform. Node's website and this <a target="_blank" href="http://stackoverflow.com/questions/2353818/how-do-i-get-started-with-node-js">stackOverflow thread</a> offer excellent starting points to get to grasps with node.</p>
+      <p><a target="_blank" href="https://nodejs.org/" rel="noopener">Node.js</a> is a JavaScript run-time, popular for being a web server platform. Node's website and this <a target="_blank" href="https://stackoverflow.com/questions/2353818/how-do-i-get-started-with-node-js" rel="noopener">stackOverflow thread</a> offer excellent starting points to get to grasps with node.</p>
     </div>
   </div>
   <div class="well">
@@ -64,17 +64,17 @@
     <p>
       Once you're familiar with the foundation technology, check out the MEAN.JS Documentation:
       <ul>
-        <li><a target="_blank" href="http://meanjs.org/docs.html">MEAN.JS Documentation</a>
+        <li><a target="_blank" href="https://meanjs.org/docs.html" rel="noopener">MEAN.JS Documentation</a>
         </li>
-        <!-- <li><a target="_blank" href="http://meanjs.org/generator.html">Yeoman Generator</a>
+        <!-- <li><a target="_blank" href="https://meanjs.org/generator.html" rel="noopener">Yeoman Generator</a>
 				</li> -->
-        <li><a target="_blank" href="http://meanjs.org/modules.html">Modules</a>
+        <li><a target="_blank" href="https://meanjs.org/modules.html" rel="noopener">Modules</a>
         </li>
-        <li><a target="_blank" href="http://meanjs.org/changelog.html">Changelog</a>
+        <li><a target="_blank" href="https://meanjs.org/changelog.html" rel="noopener">Changelog</a>
         </li>
-        <li><a target="_blank" href="http://meanjs.org/community.html">Community</a>
+        <li><a target="_blank" href="https://meanjs.org/community.html" rel="noopener">Community</a>
         </li>
-        <li><a target="_blank" href="http://blog.meanjs.org">Blog</a>
+        <li><a target="_blank" href="http://blog.meanjs.org" rel="noopener">Blog</a>
         </li>
       </ul>
     </p>


### PR DESCRIPTION
This PR does the following:
- When possible, use the https version of the urls
- Removed one dead SO link regarding Express
- Added `rel="noopener"` in links using `target="_blank"`

More info about the use of `rel="noopener"` for security reasons:
https://developers.google.com/web/tools/lighthouse/audits/noopener
https://mathiasbynens.github.io/rel-noopener/

I understand that this view just has generic content which is meant to be replaced but still it's good to have this covered :)