### PR TITLE
feat (ide) Add vscode launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,133 @@
+{
+    // Use IntelliSense to learn about possible Node.js debug attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [{
+        "type": "node",
+        "request": "launch",
+        "name": "GulpDefault",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js"
+    }, {
+        "type": "node",
+        "request": "launch",
+        "name": "GulpBuild",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "build"
+        ]
+    }, {
+        "type": "node",
+        "request": "launch",
+        "name": "GulpProd",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "prod"
+        ]
+    }, {
+        "type": "node",
+        "request": "launch",
+        "name": "GulpSeed",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "seed"
+       ]
+    }, {
+        "type": "node",
+        "request": "launch",
+        "name": "GulpSeedProd",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "seed:prod"
+       ]
+    }, {
+        "type": "node",
+        "request": "launch",
+        "name": "GulpSeedTest",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "seed:test"
+       ]
+    }, {
+        "type": "node",
+        "request": "launch",
+        "name": "GulpTest",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "test"
+       ]
+    }, {
+        "type": "node",
+        "request": "launch",
+        "name": "GulpLint",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "lint"
+       ]
+    }, {
+        "type": "node",
+        "request": "launch",
+        "name": "GulpTestSever",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "test:server"
+       ]
+    }, {
+        "type": "node",
+        "request": "launch",
+        "name": "GulpTestSeverWatch",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "test:server:watch"
+       ]
+    }, {
+        "type": "node",
+        "request": "launch",
+        "name": "GulpTestClient",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "test:client"
+       ]
+    }, {
+        "type": "node",
+        "request": "launch",
+        "name": "GulpTestE2E",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "test:e2e"
+       ]
+    }, {
+        "type": "node",
+        "request": "launch",
+        "name": "GulpTestCoverage",
+        "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "test:coverage"
+       ]
+    }, {
+        "type": "node",
+        "request": "attach",
+        "name": "DebugBackend",
+        "port": 5858,
+        "timeout": 40000
+    }, {
+        "type": "chrome",
+        "request": "launch",
+        "name": "LaunchChrome",
+        "url": "http://localhost:3000",
+        "webRoot": "${workspaceRoot}"
+    }],
+    "compounds": [
+        {
+            "name": "Debug Front-end",
+            "configurations": ["GulpDefault", "LaunchChrome"]
+        },{
+            "name": "Debug Back-end",
+            "configurations": ["GulpDefault", "DebugBackend"]
+        },{
+            "name": "Debug Full-stack",
+            "configurations": ["GulpDefault", "DebugBackend", "LaunchChrome"]
+        }
+
+    ]
+}


### PR DESCRIPTION
Adds configuration for vscode:
- Adds most gulp tasks
- Adds chrome debugging: Debug client-side within vscode
- Adds debug attach: Debug server-side within vscode
- Adds compound tasks to start multiple combos of the above