### PR TITLE
Update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update -q  \
  ssh \
  gcc \
  make \
+ npm \
+ libpng-dev \ 
  build-essential \
  libkrb5-dev \
  sudo \
@@ -38,7 +40,7 @@ RUN sudo apt-get install -yq nodejs \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install MEAN.JS Prerequisites
-RUN npm install --quiet -g gulp bower yo mocha karma-cli pm2 && npm cache clean
+RUN npm install --quiet -g gulp bower yo mocha karma-cli pm2 pngquant-bin && npm cache clean
 
 RUN mkdir -p /opt/mean.js/public/lib
 WORKDIR /opt/mean.js


### PR DESCRIPTION
fix: Docker thows an error on build

I had an error on **docker-compose up**:
```
npm ERR! pngquant-bin@4.0.0 postinstall: `node lib/install.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the pngquant-bin@4.0.0 postinstall script 'node lib/install.js'
```
I was able to resolve it by following this solution:
(https://github.com/imagemin/pngquant-bin/issues/78#issuecomment-373972847)

